### PR TITLE
add null validator to publisher_url field

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -314,7 +314,7 @@
         "nl": "Het adres van de website moet met  \"http://\" of \"https://\" beginnen.",
         "de": "Die Adresse der Website muss mit \"http://\" of \"https://\" anfangen. "
       },
-      "validators": "url_validator"
+      "validators": "url_validator benap_is_choice_null"
     },
     {
       "field_name": "p_tel",


### PR DESCRIPTION
Deze pr voegt de null validator toe aan het veld publisher_url voor een dataset. Als er niks wordt ingevuld, zal de state in de database op deleted te komen staan.