### PR TITLE
card_441/description

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -128,7 +128,6 @@
     },
     {
       "field_name": "notes_translated",
-      "preset": "fluent_markdown",
       "label": {
         "en": "Description of dataset",
         "fr": "Description du jeux de données",
@@ -153,7 +152,11 @@
         "fr",
         "de"
       ],
-      "display_snippet": "fluent_markdown_fallback.html"
+      "form_snippet": "fluent_markdown.html",
+      "display_snippet": "fluent_markdown.html",
+      "error_snippet": "fluent_text.html",
+      "output_validators": "fluent_core_translated_output",
+      "validators": "fluent_text"
     },
     {
       "field_name": "cont_res",


### PR DESCRIPTION
Deze pr voegt de nieuwe null validator van ckanext-fluent toe aan het veld notes_translated (description). Wanneer er geen waarde wordt ingevuld in alle velden van description komt de state op deleted te staan.