### PR TITLE
Database consistency optional empty values - card 441

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -112,7 +112,8 @@
         "de": "Wählen Sie einen oder mehrere relevante Datensatztypen aus."
       },
       "choices_helper": "benap_ontology_helper",
-      "benap_helper_ontology": "dataset_type"
+      "benap_helper_ontology": "dataset_type",
+      "validators":"benap_is_choice_null"
     },
     {
       "field_name": "name",

--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -1371,3 +1371,19 @@ def is_nap_checked(datasetID):
     datasetFetched = toolkit.get_action('package_show')(data_dict={'id':datasetID})
     return "True" if datasetFetched.get("nap_checked") is not None and datasetFetched['nap_checked'] else "False"
 
+def convert_validation_list_to_JSON(data):
+    """
+    Converts a string containing a JSON-like structure into a proper JSON list format.
+
+    If the input string contains curly braces ('{', '}'), it is assumed to be a
+    JSON-like structure and is converted by replacing the curly braces with square
+    brackets ('[', ']'). If not, the string is wrapped in a JSON array format.
+
+    This function is particularly useful for handling cases where a validation
+    process converts a JSON string into a list format unexpectedly.
+    """
+    if '{' in data:
+        data_string = data.replace('{', '[').replace('}', ']')
+    else:
+        data_string = '["{}"]'.format(data)
+    return data_string

--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -1370,3 +1370,4 @@ def is_nap_checked(datasetID):
         return "False"
     datasetFetched = toolkit.get_action('package_show')(data_dict={'id':datasetID})
     return "True" if datasetFetched.get("nap_checked") is not None and datasetFetched['nap_checked'] else "False"
+

--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -1370,20 +1370,3 @@ def is_nap_checked(datasetID):
         return "False"
     datasetFetched = toolkit.get_action('package_show')(data_dict={'id':datasetID})
     return "True" if datasetFetched.get("nap_checked") is not None and datasetFetched['nap_checked'] else "False"
-
-def convert_validation_list_to_JSON(data):
-    """
-    Converts a string containing a JSON-like structure into a proper JSON list format.
-
-    If the input string contains curly braces ('{', '}'), it is assumed to be a
-    JSON-like structure and is converted by replacing the curly braces with square
-    brackets ('[', ']'). If not, the string is wrapped in a JSON array format.
-
-    This function is particularly useful for handling cases where a validation
-    process converts a JSON string into a list format unexpectedly.
-    """
-    if '{' in data:
-        data_string = data.replace('{', '[').replace('}', ']')
-    else:
-        data_string = '["{}"]'.format(data)
-    return data_string

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -12,7 +12,9 @@ from ckanext.benap.helpers import ontology_helper, scheming_language_text_fallba
     forum_url, filter_default_tags_only, getTranslatedVideoUrl, show_element, get_organization_by_id, benap_fluent_label, \
     translate_organization_filter, is_user_sysAdmin, is_nap_checked
 from ckanext.benap.util.forms import map_for_form_select
-from ckanext.benap.validators import phone_number_validator, countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin
+from ckanext.benap.validators import phone_number_validator, \
+    countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin, \
+    is_choice_null
 from ckanext.benap.logic.auth.get import user_list
 
 
@@ -78,6 +80,7 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'benap_is_after_start': is_after_start,
             'benap_https_validator': https_validator,
             'benap_modified_by_sysadmin': modified_by_sysadmin,
+            'benap_is_choice_null': is_choice_null
         }
 
     # IAuthFunctions
@@ -102,16 +105,44 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
 
     # IPackageController
     def before_index(self, pkg_dict):
+        #print("BEFORE INDEX PKG")
+        #print('==========')
+        #print("pkg-regions-coverd::", pkg_dict["regions_covered"])
+        #print("type::", type(pkg_dict["regions_covered"]))
+        #print('')
+        #print("nap_type::", pkg_dict["nap_type"])
+        #print("type::", type(pkg_dict["nap_type"]))
+        #print('')
+        #print("pkg-dataset-type::", pkg_dict["its_dataset_type"])
+        #print("type::", type(pkg_dict["its_dataset_type"]))
+        #print('')
         if "regions_covered" in pkg_dict:
             pkg_dict["regions_covered"] = json.loads(pkg_dict["regions_covered"])
         if "nap_type" in pkg_dict:
             pkg_dict["nap_type"] = json.loads(pkg_dict["nap_type"])
+        
         if "its_dataset_type" in pkg_dict:
-            pkg_dict["its_dataset_type"] = json.loads(pkg_dict["its_dataset_type"])
+            try:
+                ## only when validation is used in json schema is next fct needed
+                converted_list = convert_validation_list_to_JSON(pkg_dict["its_dataset_type"])
+                pkg_dict["its_dataset_type"] = json.loads(converted_list)
+            except Exception:
+                pkg_dict["its_dataset_type"] = json.loads(pkg_dict["its_dataset_type"])
+                print("No validation conversion needed")
+            
         return pkg_dict
 
     def before_view(self, pkg_dict):
         pkg_dict.pop('agreement_declaration_nap', None)
         return pkg_dict
+
+
+def convert_validation_list_to_JSON(data):  
+    #aint sure aint pretty - scheming converts a jsonstring to list when the validation option is used
+    if '{' in data:
+        data_string = data.replace('{', '[').replace('}', ']')
+    else:
+        data_string = '["{}"]'.format(data)
+    return data_string
 
 

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -10,7 +10,7 @@ from ckanext.benap.helpers import ontology_helper, scheming_language_text_fallba
     package_notes_translated_fallback, field_translated_fallback, organisation_names_for_autocomplete, \
     get_translated_tags, scheming_language_text, format_datetime, get_translated_tag, get_translated_tag_with_name, \
     forum_url, filter_default_tags_only, getTranslatedVideoUrl, show_element, get_organization_by_id, benap_fluent_label, \
-    translate_organization_filter, is_user_sysAdmin, is_nap_checked
+    translate_organization_filter, is_user_sysAdmin, is_nap_checked, convert_validation_list_to_JSON
 from ckanext.benap.util.forms import map_for_form_select
 from ckanext.benap.validators import phone_number_validator, \
     countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin, \
@@ -105,22 +105,10 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
 
     # IPackageController
     def before_index(self, pkg_dict):
-        #print("BEFORE INDEX PKG")
-        #print('==========')
-        #print("pkg-regions-coverd::", pkg_dict["regions_covered"])
-        #print("type::", type(pkg_dict["regions_covered"]))
-        #print('')
-        #print("nap_type::", pkg_dict["nap_type"])
-        #print("type::", type(pkg_dict["nap_type"]))
-        #print('')
-        #print("pkg-dataset-type::", pkg_dict["its_dataset_type"])
-        #print("type::", type(pkg_dict["its_dataset_type"]))
-        #print('')
         if "regions_covered" in pkg_dict:
             pkg_dict["regions_covered"] = json.loads(pkg_dict["regions_covered"])
         if "nap_type" in pkg_dict:
             pkg_dict["nap_type"] = json.loads(pkg_dict["nap_type"])
-        
         if "its_dataset_type" in pkg_dict:
             try:
                 ## only when validation is used in json schema is next fct needed
@@ -128,21 +116,9 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
                 pkg_dict["its_dataset_type"] = json.loads(converted_list)
             except Exception:
                 pkg_dict["its_dataset_type"] = json.loads(pkg_dict["its_dataset_type"])
-                print("No validation conversion needed")
-            
+
         return pkg_dict
 
     def before_view(self, pkg_dict):
         pkg_dict.pop('agreement_declaration_nap', None)
         return pkg_dict
-
-
-def convert_validation_list_to_JSON(data):  
-    #aint sure aint pretty - scheming converts a jsonstring to list when the validation option is used
-    if '{' in data:
-        data_string = data.replace('{', '[').replace('}', ']')
-    else:
-        data_string = '["{}"]'.format(data)
-    return data_string
-
-

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -10,7 +10,7 @@ from ckanext.benap.helpers import ontology_helper, scheming_language_text_fallba
     package_notes_translated_fallback, field_translated_fallback, organisation_names_for_autocomplete, \
     get_translated_tags, scheming_language_text, format_datetime, get_translated_tag, get_translated_tag_with_name, \
     forum_url, filter_default_tags_only, getTranslatedVideoUrl, show_element, get_organization_by_id, benap_fluent_label, \
-    translate_organization_filter, is_user_sysAdmin, is_nap_checked, convert_validation_list_to_JSON
+    translate_organization_filter, is_user_sysAdmin, is_nap_checked
 from ckanext.benap.util.forms import map_for_form_select
 from ckanext.benap.validators import phone_number_validator, \
     countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin, \
@@ -122,3 +122,20 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
     def before_view(self, pkg_dict):
         pkg_dict.pop('agreement_declaration_nap', None)
         return pkg_dict
+
+def convert_validation_list_to_JSON(data):
+    """
+    Converts a string containing a JSON-like structure into a proper JSON list format.
+
+    If the input string contains curly braces ('{', '}'), it is assumed to be a
+    JSON-like structure and is converted by replacing the curly braces with square
+    brackets ('[', ']'). If not, the string is wrapped in a JSON array format.
+
+    This function is particularly useful for handling cases where a validation
+    process converts a JSON string into a list format unexpectedly.
+    """
+    if '{' in data:
+        data_string = data.replace('{', '[').replace('}', ']')
+    else:
+        data_string = '["{}"]'.format(data)
+    return data_string

--- a/ckanext/benap/util/forms.py
+++ b/ckanext/benap/util/forms.py
@@ -1,7 +1,6 @@
 
 def map_for_form_select(tuple_list):
     """
-
     :param tuple_list: array of tuples (key, value)
     :return: json array suitable for CKAN's form.select
     """

--- a/ckanext/benap/validators.py
+++ b/ckanext/benap/validators.py
@@ -4,6 +4,7 @@ from ckan.common import _
 from ckan.logic.validators import Invalid
 from ckanext.scheming.validation import scheming_validator
 import ckan.plugins.toolkit as toolkit
+from ckan.lib.navl.dictization_functions import Missing
 
 
 # pattern from http://phoneregex.com/
@@ -77,6 +78,7 @@ def https_validator(value, context):
 
 
 def modified_by_sysadmin(schema_value, package):
+     
      user  = package.get("auth_user_obj")
      #parse schema_value
      trueValues = {"true"}
@@ -94,3 +96,12 @@ def modified_by_sysadmin(schema_value, package):
             return schema_value
      else:
          raise Invalid(_('Logged in one must be'))
+     
+def is_choice_null(value):
+    print('/n')
+    print("FCT:_is_choice_null")
+    print("value::", value)
+    if isinstance(value, Missing) or value =='':
+        print("Is missing")
+        return None
+    return value

--- a/ckanext/benap/validators.py
+++ b/ckanext/benap/validators.py
@@ -98,10 +98,6 @@ def modified_by_sysadmin(schema_value, package):
          raise Invalid(_('Logged in one must be'))
      
 def is_choice_null(value):
-    print('/n')
-    print("FCT:_is_choice_null")
-    print("value::", value)
     if isinstance(value, Missing) or value =='':
-        print("Is missing")
         return None
     return value


### PR DESCRIPTION
deze pr voegt een nieuwe manier toe om optionele legel waarden te verwerken in de database. Wanneer en veld leeg is zal de validator kolom op deleted te komen staan. Dit zorgt voor database consistentie. Null waarden lukken moeizaam in ckan dus dit is momenteel de beste optie.