### PR TITLE
Database consistency optional empty values - card 441

### DIFF
--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -1370,3 +1370,20 @@ def is_nap_checked(datasetID):
         return "False"
     datasetFetched = toolkit.get_action('package_show')(data_dict={'id':datasetID})
     return "True" if datasetFetched.get("nap_checked") is not None and datasetFetched['nap_checked'] else "False"
+
+def convert_validation_list_to_JSON(data):
+    """
+    Converts a string containing a JSON-like structure into a proper JSON list format.
+
+    If the input string contains curly braces ('{', '}'), it is assumed to be a
+    JSON-like structure and is converted by replacing the curly braces with square
+    brackets ('[', ']'). If not, the string is wrapped in a JSON array format.
+
+    This function is particularly useful for handling cases where a validation
+    process converts a JSON string into a list format unexpectedly.
+    """
+    if '{' in data:
+        data_string = data.replace('{', '[').replace('}', ']')
+    else:
+        data_string = '["{}"]'.format(data)
+    return data_string

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -10,7 +10,7 @@ from ckanext.benap.helpers import ontology_helper, scheming_language_text_fallba
     package_notes_translated_fallback, field_translated_fallback, organisation_names_for_autocomplete, \
     get_translated_tags, scheming_language_text, format_datetime, get_translated_tag, get_translated_tag_with_name, \
     forum_url, filter_default_tags_only, getTranslatedVideoUrl, show_element, get_organization_by_id, benap_fluent_label, \
-    translate_organization_filter, is_user_sysAdmin, is_nap_checked
+    translate_organization_filter, is_user_sysAdmin, is_nap_checked, convert_validation_list_to_JSON
 from ckanext.benap.util.forms import map_for_form_select
 from ckanext.benap.validators import phone_number_validator, \
     countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin, \
@@ -69,6 +69,7 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'benap_fluent_label': benap_fluent_label,
             'benap_is_user_sysAdmin': is_user_sysAdmin,
             'benap_is_nap_checked':is_nap_checked,
+            'convert_validation_list_to_JSON': convert_validation_list_to_JSON
         }
 
     # IValidators
@@ -122,20 +123,3 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
     def before_view(self, pkg_dict):
         pkg_dict.pop('agreement_declaration_nap', None)
         return pkg_dict
-
-def convert_validation_list_to_JSON(data):
-    """
-    Converts a string containing a JSON-like structure into a proper JSON list format.
-
-    If the input string contains curly braces ('{', '}'), it is assumed to be a
-    JSON-like structure and is converted by replacing the curly braces with square
-    brackets ('[', ']'). If not, the string is wrapped in a JSON array format.
-
-    This function is particularly useful for handling cases where a validation
-    process converts a JSON string into a list format unexpectedly.
-    """
-    if '{' in data:
-        data_string = data.replace('{', '[').replace('}', ']')
-    else:
-        data_string = '["{}"]'.format(data)
-    return data_string

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -69,7 +69,7 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'benap_fluent_label': benap_fluent_label,
             'benap_is_user_sysAdmin': is_user_sysAdmin,
             'benap_is_nap_checked':is_nap_checked,
-            'convert_validation_list_to_JSON': convert_validation_list_to_JSON
+            'benap_convert_validation_list_to_JSON': convert_validation_list_to_JSON
         }
 
     # IValidators


### PR DESCRIPTION
deze pr voegt een nieuwe manier toe om optionele lege waarden te verwerken in de database. Wanneer en veld leeg is zal de validator kolom op deleted te komen staan. Dit zorgt voor database consistentie. Null waarden lukken moeizaam in ckan dus dit is momenteel de beste optie.