### PR TITLE
card 22 - Contract or License veranderen van dataset naar resource + van 1:1 naar 1:n

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -459,25 +459,6 @@
       "validators": "scheming_required tag_string_convert"
     },
     {
-      "field_name": "contract_license",
-      "label": {
-        "en": "Contract or license",
-        "fr": "Contrat ou licence",
-        "nl": "Contract of licentie",
-        "de": "Vertrag oder Lizenz"
-      },
-      "preset": "select",
-      "choices_helper": "benap_ontology_helper",
-      "help_text": {
-        "en": "Describes the conditions of use of the data set.",
-        "fr": "Décrit les conditions d'utilisation du jeu de données.",
-        "nl": "Beschrijft de gebruiksvoorwaarden van de dataset.",
-        "de": "Beschreibt die Nutzungsbedingungen des Datensatzes."
-      },
-      "benap_helper_ontology": "contract_license",
-      "required": "true"
-    },
-    {
       "field_name": "license_id",
       "label": {
         "en": "License type",
@@ -824,6 +805,25 @@
       },
       "choices_helper": "benap_ontology_helper",
       "benap_helper_ontology": "georeferencing_method"
+    },
+    {
+      "field_name": "contract_license",
+      "label": {
+        "en": "Contract or license",
+        "fr": "Contrat ou licence",
+        "nl": "Contract of licentie",
+        "de": "Vertrag oder Lizenz"
+      },
+      "preset": "multiple_checkbox",
+      "choices_helper": "benap_ontology_helper",
+      "help_text": {
+        "en": "Describes the conditions of use of the data set. It is possible to select multiple categories.",
+        "fr": "Décrit les conditions d'utilisation du jeu de données. Il est possible de sélectionner plusieurs catégories.",
+        "nl": "Beschrijft de gebruiksvoorwaarden van de dataset. Het is mogelijk om meerdere categorieën te selecteren.",
+        "de": "Beschreibt die Nutzungsbedingungen des Datensatzes. Es ist möglich, mehrere Kategorien auszuwählen."
+      },
+      "benap_helper_ontology": "contract_license",
+      "required": "true"
     }
   ]
 }

--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -849,41 +849,41 @@ def ontology_helper(context):
         ])
     elif ontology == "contract_license":
         return map_for_form_select([
-            ('nolinoco', {
-                "en": u"No license – No contract",
-                "fr": u"Pas de licence - Pas de contrat",
-                "nl": u"Geen licentie - Geen contract",
-                "de": u"Keine Lizenz - Kein Vertrag"
+            ('https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/contractual-arrangement', {
+                "en": u"Contractual arrangement",
+                "fr": u"Arrangement contractuel",
+                "nl": u"Contractuele regeling",
+                "de": u"Vertragliche vereinbarung"
             }),
-            ('lifree', {
-                "en": u"Licence and Free of charge",
-                "fr": u"Licence et gratuit",
-                "nl": u"Licentie en gratis",
-                "de": u"Lizenz und kostenlos"
+            ('https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/fee-required', {
+                "en": u"Fee required",
+                "fr": u"Frais requis",
+                "nl": u"Vergoeding vereist",
+                "de": u"Gebühr erforderlich"
             }),
-            ('linotfree', {
-                "en": u"Licence and Fee",
-                "fr": u"Licence et frais",
-                "nl": u"Licentie en vergoeding",
-                "de": u"Lizenz und Gebühr"
+            ('https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/free-of-charge', {
+                "en": u"Free of charge",
+                "fr": u"Gratuit",
+                "nl": u"Gratis",
+                "de": u"Kostenlos"
             }),
-            ('cofree', {
-                "en": u"Contract and Free of charge",
-                "fr": u"Contrat et gratuit",
-                "nl": u"Contract en gratis",
-                "de": u"Vertrag und kostenlos"
+            ('https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided', {
+                "en": u"Licence provided",
+                "fr": u"Licence fournie",
+                "nl": u"Licentie verstrekt",
+                "de": u"Lizenz bereitgestellt"
             }),
-            ('conotfree', {
-                "en": u"Contract and Fee",
-                "fr": u"Contrat et frais",
-                "nl": u"Contract en vergoeding",
-                "de": u"Vertrag und Gebühr"
+            ('https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/royalty-free', {
+                "en": u"Royalty-free",
+                "fr": u"Libre de droits",
+                "nl": u"Royaltyvrij",
+                "de": u"Lizenzfrei"
             }),
-            ('notrelevant', {
-                "en": u"Not relevant",
-                "fr": u"Non pertinent",
-                "nl": u"Niet relevant",
-                "de": u"Nicht relevant"
+            ('https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/other', {
+                "en": u"Other",
+                "fr": u"Autre",
+                "nl": u"Andere",
+                "de": u"Andere"
             }),
         ])
 


### PR DESCRIPTION
Deze pr verschuift het veld contract or license van datasetniveau naar resourceniveau. Ook de cardinaliteit werd aangepast van 1..1 naar 1..n. De selectieopties werden aangepast zodat ze overeenkomen met de controlled voc van mobilitydcat-ap.