### PR TITLE
card 15, 24, 25 - Address field + Contact point field + organization/publisher fields retuning. 

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -199,10 +199,10 @@
     {
       "field_name": "owner_org",
       "label": {
-        "en": "Organisation name [contact point]",
-        "fr": "Nom de l'organisation [point de contact] ",
-        "nl": "Naam van de organisatie  [contactpunt]",
-        "de": "Name der Organisation  [Kontaktpunkt]"
+        "en": "Organisation name [publisher]",
+        "fr": "Nom de l'organisation [éditeur] ",
+        "nl": "Naam van de organisatie [uitgever]",
+        "de": "Name der Organisation  [Herausgeber]"
       },
       "label_dataset_organization":{
         "en": "Visibility",
@@ -212,10 +212,10 @@
       },
       "preset": "dataset_organization",
       "help_text": {
-        "en": "The \"contact point\", describes an organisation, if applicable a person, which is responsible for the creation and maintenance of the metadata. This person or organization is the single point of contact for the present metadata set. The next field may be used to keep the dataset \"private\" within the organisation for internal review before effective publication.",
-        "fr": "Le \"point de contact\" décrit une organisation, ou une personne si d'application, qui est responsable de la création et de la mise à jour des métadonnées. Cette personne ou organisation est le point de contact unique pour le présent jeu de métadonnées.  Le champ suivant peut être utilisé pour garder le jeu de données \"privé\" au sein de l'organisation pour révision interne avant publication effective.",
-        "nl": "Het \"contactpunt\" beschrijft een organisatie, of een persoon indien van toepassing, die verantwoordelijk is voor de aanmaak en bijwerking van de metadata. Deze persoon of organisatie is het één contactpunt voor deze set van metadata. Het volgende veld kan gebruikt worden om ter interne herziening voor effectieve publicatie de dataset \"privé\" te houden binnen de organisatie.",
-        "de": "Der \"Kontaktpunkt\" beschreibt eine Organisation, oder gegebenenfalls eine Person, die für die Herstellung und Aktualisierung von Metadaten verantwortlich ist. Diese Person oder Organisation ist der einzige Kontaktpunkt für diesen Metadatensatz. Das folgende Feld kann benutzt werden, um für interne Prüfung vor der effektiven Publikation den Datensatz \"privat\" zu halten innerhalb von der Organisation. "
+        "en": "The \"publisher\" describes an organization that publishes the datasets (we are not refering to the metadata here, but rather to the data themselves). The publisher is responsible for the given information and must be contacted by data consumers if a contract needs to be concluded. The next field may be used to keep the dataset \"private\" within the organisation for internal review before effective publication.",
+        "fr": "L'\"éditeur\" décrit une organisation qui publie les jeux de données (nous ne nous référons pas ici aux métadonnées mais plutôt aux données elles-mêmes). L'éditeur est responsable des informations données et doit être contacté(e) par les consommateurs de données si un contrat doit être conclu. Le champ suivant peut être utilisé pour garder le jeu de données \"privé\" au sein de l'organisation pour révision interne avant publication effective.",
+        "nl": "De \"uitgever\" beschrijft een organisatie die de datasets publiceert (we verwijzen hier niet naar de metadata maar eerder naar de gegevens zelfs). De uitgever is verantwoordelijk voor de gegeven informatie en moet door gegevensverbruikers gecontacteerd worden indien een overeenkomst moet worden gesloten. Het volgende veld kan gebruikt worden om ter interne herziening voor effectieve publicatie de dataset \"privé\" te houden binnen de organisatie.",
+        "de": "Der \"Herausgeber\" beschreibt eine organisation, die die Datensätze publiziert (wir beziehen uns hier nicht auf die Metadaten sondern eher auf die Daten selbst). Der Herausgeber ist verantwortlich für die gegebene Information und muss von Datenverbrauchern kontaktiert werden, wenn ein Vertrag geschlossen werden muss. Das folgende Feld kann benutzt werden, um für interne Prüfung vor der effektiven Publikation den Datensatz \"privat\" zu halten innerhalb von der Organisation."
       },
       "required": "true",
       "help_text_visibility":{
@@ -230,36 +230,94 @@
         "fr": "ici.",
         "nl": "hier.",
         "de": "hier."
-      }
+      },
+      "display_snippet": "organization.html"
     },
     {
-      "field_name": "contact_name",
+      "field_name": "contact_point",
+      "label": {
+        "en": "Contact point",
+        "fr": "Point de contact",
+        "nl": "contactpunt",
+        "de": "Kontaktpunkt"
+      },
+      "help_text": {
+        "en": "The contact point of the metadata, divided into three fields: name (mandatory), email (mandatory), and phone number (optional).",
+        "fr": "Le point de contact des métadonnées, divisé en trois champs : nom (obligatoire), email (obligatoire) et numéro de téléphone (optionnel).",
+        "nl": "Het contactpunt van de metadata, verdeeld in drie velden: naam (verplicht), e-mail (verplicht) en telefoonnummer (optioneel).",
+        "de": "Der Ansprechpartner der Metadaten, unterteilt in drei Felder: Name (verpflichtend), E-Mail (verpflichtend) und Telefonnummer (optional)."
+      },
+      "form_snippet": "nested_field.html",
+      "display_snippet": null,
+      "nested_fields": [
+        {
+            "field_name": "contact_point_name",
+            "form_snippet": "text_autocomplete.html"
+        },
+        {
+            "field_name": "contact_point_email",
+            "form_snippet": "text.html"
+        },
+        {
+            "field_name": "contact_point_phone",
+            "form_snippet": "text.html"
+        }
+      ]
+    },
+    {
+      "field_name": "contact_point_name",
       "label": {
         "en": "Name [contact point]",
         "fr": "Nom [point de contact]",
         "nl": "Naam [contactpunt]",
         "de": "Name [Kontaktpunkt]"
       },
-      "form_placeholder": "John Doe",
-      "display_property": "dc:",
-      "required": "true"
+      "help_text": {
+        "en": "The \"contact point\", describes an organisation, if applicable a person, which is responsible for the creation and maintenance of the metadata. This person or organization is the single point of contact for the present metadata set.",
+        "fr": "Le \\\"point de contact\\\" décrit une organisation, ou une personne si d'application, qui est responsable de la création et de la mise à jour des métadonnées. Cette personne ou organisation est le point de contact unique pour le présent jeu de métadonnées.",
+        "nl": "Het \\\"contactpunt\\\" beschrijft een organisatie, of een persoon indien van toepassing, die verantwoordelijk is voor de aanmaak en bijwerking van de metadata. Deze persoon of organisatie is het één contactpunt voor deze set van metadata.",
+        "de": "Der \"Kontaktpunkt\" beschreibt eine Organisation, oder gegebenenfalls eine Person, die für die Herstellung und Aktualisierung von Metadaten verantwortlich ist. Diese Person oder Organisation ist der einzige Kontaktpunkt für diesen Metadatensatz."
+      },
+      "required": "true",
+      "form_snippet": null
     },
     {
-      "field_name": "publisher_org",
+      "field_name": "contact_point_email",
       "label": {
-        "en": "Organisation name [publisher]",
-        "fr": "Nom de l'organisation [éditeur] ",
-        "nl": "Naam van de organisatie [uitgever]",
-        "de": "Name der Organisation  [Herausgeber]"
+        "en": "E-mail [contact point]",
+        "fr": "E-mail [point de contact]",
+        "nl": "E-mail [contactpunt]",
+        "de": "E-mail [Kontaktpunkt]"
       },
       "help_text": {
-        "en": "The \"publisher\" describes an entity (company and person) that publishes the datasets (we are not refering to the metadata here, but rather to the data themselves). He or she is responsible for the given information and must be contacted by data consumers if a contract needs to be concluded.",
-        "fr": "L'\"éditeur\" décrit une entité (entreprise et personne) qui publie les jeux de données (nous ne nous référons pas ici aux métadonnées mais plutôt aux données elles-mêmes). Il ou elle est responsable des informations données et doit être contacté(e) par les consommateurs de données si un contrat doit être conclu.",
-        "nl": "De \"uitgever\" beschrijft een entiteit (bedrijf of persoon) die de datasets publiceert (we verwijzen hier niet naar de metadata maar eerder naar de gegevens zelfs). Hij of zij is verantwoordelijk voor de gegeven informatie en moet door gegevensverbruikers gecontacteerd worden indien een overeenkomst moet worden gesloten. ",
-        "de": "Der \"Herausgeber\" beschreibt eine Entität (Unternehmen oder Person), die die Datensätze publiziert (wir beziehen uns hier nicht auf die Metadaten sondern eher auf die Daten selbst). Er oder sie ist verantwortlich für die gegebene Information und muss von Datenverbrauchern kontaktiert werden, wenn ein Vertrag geschlossen werden muss."
+        "en": "The email adress must contain @ and a dot.",
+        "fr": "L'adresse e-mail doit contenir @ et un point.",
+        "nl": "Het e-mailadres moet  @ en een punt inhouden.",
+        "de": "Die E-Mail muss  @ und einen Punkt beinhalten."
       },
-      "form_snippet": "text_autocomplete.html",
-      "required": "true"
+      "required": "true",
+      "form_snippet": null,
+      "display_snippet": "email.html",
+      "form_placeholder": "example@example.com",
+      "validators": "email_validator not_empty benap_contact_point_org_fields_consistency_check"
+    },
+    {
+      "field_name": "contact_point_phone",
+      "label": {
+        "en": "Telephone number [contact point]",
+        "fr": "Numéro de téléphone [point de contact]",
+        "nl": "Telefoonnummer [contactpunt]",
+        "de": "Telefonnummer [Kontaktpunkt]"
+      },
+      "help_text": {
+        "en": "The telephone number must start with the country prefix (e.g. \",+32\" for Belgium) and may only contain numbers from 0 to 9 besides the \"+\" sign.",
+        "fr": "Le numéro de téléphone doit commencer par le préfixe du pays (par ex. \"+32\" pour la Belgique) et ne peut contenir que des chiffres de 0 à 9 en plus du signe \"+\".",
+        "nl": "Het telefoonnummer moet met het netnummer van het land beginnen (bv. \"+32\" voor België) en kan naast de teken \"+\" alleen maar cijfers van 0 tot 9 inhouden.",
+        "de": "Die Telefonnummer muss mit der Vorwahl des Landes anfangen (zum B. \"+32\" für Belgien) und kann neben dem Zeichen \"+\" nur Zahlen von 0 bis 9 beinhalten."
+      },
+      "form_placeholder": "+32XXXXXXXX",
+      "form_snippet": null,
+      "validators": "phone_number_validator benap_contact_point_org_fields_consistency_check"
     },
     {
       "field_name": "publisher_name",
@@ -273,15 +331,15 @@
       "required": "true"
     },
     {
-      "field_name": "p_address",
+      "field_name": "publisher_address",
       "label": {
         "en": "Address [publisher]",
-        "fr": "Adresse  [éditeur]",
+        "fr": "Adresse [éditeur]",
         "nl": "Adres [uitgever]",
         "de": "Adresse [Herausgeber]"
       },
-      "form_placeholder": "Boulevard Anspach, 1 - 1000 Bruxelles (Belgique)",
-      "required": "true"
+      "form_snippet": null,
+      "display_snippet": "address.html"
     },
     {
       "field_name": "publisher_email",

--- a/ckanext/benap/benap_schema_organization.json
+++ b/ckanext/benap/benap_schema_organization.json
@@ -161,21 +161,137 @@
       "required":true
     },
     {
-      "field_name": "do_address",
+      "field_name": "address",
       "label": {
         "en": "Address",
-        "fr": "Adresse",
+        "fr": "Addresse",
         "nl": "Adres",
-        "de": "Adresse"
+        "de": "Addresse"
       },
       "help_text": {
-        "en": "Official address of your organisation in Belgium. If necessary, please fill it in in multiple languages, each separated by \"/\".",
-        "fr": "Adresse officielle de votre organisation en Belgique. Si nécessaire, merci de compléter dans plusieurs langues, chacune séparée par une \"/\".",
-        "nl": "Officiëel adres van je organisatie in België. Indien nodig, gelieve  in verschillende talen in te vullen, elke gescheid door een \"/\".",
-        "de": "Offizielle Adresse Ihrer Organisation in Belgien. Wenn nötig, bitte in verschiedenen Sprachen ausfüllen, jede getrennt durch ein \"/\"."
+        "en": "The complete address of an organization, divided into four fields: country, administrative area, postal code, city, and street address.",
+        "fr": "L'adresse complète d'une organisation, divisée en quatre champs : pays, zone administrative, code postal, ville et adresse de rue",
+        "nl": "Het volledige adres van een organisatie, opgesplitst in vier velden: land, administratief gebied, postcode, stad en straatadres",
+        "de": "Die vollständige Adresse einer Organisation, aufgeteilt in vier Felder: land, verwaltungsgebiet, postleitzahl, stadt und straßenadresse."
       },
-      "form_placeholder": "Boulevard Anspach, 1 - 1000 Bruxelles (Belgium)",
-      "required": true
+      "form_snippet": "nested_field.html",
+      "nested_fields": [
+        {
+            "field_name": "country",
+            "form_snippet": "text.html"
+        },
+        {
+            "field_name": "administrative_area",
+            "form_snippet": "text.html"
+        },
+        {
+            "field_name": "postal_code",
+            "form_snippet": "text.html"
+        },
+        {
+            "field_name": "city",
+            "form_snippet": "text.html"
+        },
+        {
+            "field_name": "street_address",
+            "form_snippet": "text.html"
+        }
+      ]
+    },
+    {
+      "field_name": "country",
+      "label": {
+        "en": "Country",
+        "fr": "Pays",
+        "nl": "Land",
+        "de": "Land"
+      },
+      "help_text": {
+        "en": "The country of an address of your organisation.",
+        "fr": "Le pays de l'adresse de votre organisation.",
+        "nl": "Het land van het adres van uw organisatie.",
+        "de": "Das Land der Adresse Ihrer Organisation."
+      },
+      "form_placeholder": "Belgium",
+      "required": true,
+      "form_snippet": null,
+      "display_snippet": null
+    },
+    {
+      "field_name": "administrative_area",
+      "label": {
+        "en": "Administrative area",
+        "fr": "Zone administrative",
+        "nl": "Administratief gebied",
+        "de": "Verwaltungsgebiet"
+      },
+      "help_text": {
+        "en": "The administrative area of an address of your organisation.  Depending on the country, this corresponds to a province, a county, a region, or a state.",
+        "fr": "La zone administrative de l'adresse de votre organisation. Selon le pays, cela correspond à une province, un comté, une région ou un état.",
+        "nl": "Het administratieve gebied van het adres van uw organisatie. Afhankelijk van het land komt dit overeen met een provincie, een district, een regio of een staat.",
+        "de": "Das Verwaltungsgebiet der Adresse Ihrer Organisation. Je nach Land entspricht dies einer Provinz, einem Bezirk, einer Region oder einem Staat."
+      },
+      "form_placeholder": "Brussels",
+      "required": true,
+      "form_snippet": null,
+      "display_snippet": null
+    },
+    {
+      "field_name": "postal_code",
+      "label": {
+        "en": "Postal code",
+        "fr": "Code postal",
+        "nl": "Postcode",
+        "de": "Postleitzahl"
+      },
+      "help_text": {
+        "en": "The postal code of an address of your organisation.",
+        "fr": "Le code postal de l'adresse de votre organisation.",
+        "nl": "De postcode van het adres van uw organisatie.",
+        "de": "Die Postleitzahl der Adresse Ihrer Organisation."
+      },
+      "form_placeholder": "1000",
+      "required": true,
+      "form_snippet": null,
+      "display_snippet": null
+    },
+    {
+      "field_name": "city",
+      "label": {
+        "en": "City",
+        "fr": "Ville",
+        "nl": "Stad",
+        "de": "Stadt"
+      },
+      "help_text": {
+        "en": "The city of an address of your organisation.",
+        "fr": "La ville de l'adresse de votre organisation.",
+        "nl": "De stad van het adres van uw organisatie.",
+        "de": "Die Stadt der Adresse Ihrer Organisation."
+      },
+      "form_placeholder": "Brussels",
+      "required": true,
+      "form_snippet": null,
+      "display_snippet": null
+    },
+    {
+      "field_name": "street_address",
+      "label": {
+        "en": "Street address",
+        "fr": "Adresse de rue",
+        "nl": "Straatadres",
+        "de": "Straßenadresse"
+      },
+      "help_text": {
+        "en": "The street address of your organisation.",
+        "fr": "L'adresse de rue de votre organisation.",
+        "nl": "Het straatadres van uw organisatie.",
+        "de": "Die Straßenadresse Ihrer Organisation."
+      },
+      "form_placeholder": "Boulevard Anspach 1",
+      "required": true,
+      "form_snippet": null,
+      "display_snippet": null
     },
     {
       "field_name": "do_email",
@@ -418,4 +534,3 @@
     }
   ]
 }
-

--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -1386,9 +1386,9 @@ def convert_validation_list_to_JSON(data):
         data_string = '["{}"]'.format(data)
     return data_string
 
-def benap_get_organization_field(org_id, field_name):
+def benap_get_organization_field_by_id(org_id, field_name):
     """
-    Retrieve the specified field value from an organization's data.
+    Retrieve the specified field value from an organization's data based on the organization id.
     """
     user = toolkit.get_action(u'get_site_user')(
         {
@@ -1405,6 +1405,21 @@ def benap_get_organization_field(org_id, field_name):
                                                             u'include_tags': False,
                                                             u'include_followers': False,
                                                         })
+
+    field_value = org_data.get(field_name)
+    return field_value
+
+def benap_get_organization_field_by_specified_field(org_value, field_name, search_field):
+    """
+    Retrieve the specified field value from an organization's data based on a specified search field.
+    """
+    from ckantoolkit import h
+    org_list = h.organizations_available('create_dataset')
+
+    org_data = next((org for org in org_list if org.get(search_field) == org_value), None)
+
+    if org_data is None:
+        return None
 
     field_value = org_data.get(field_name)
     return field_value

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -10,11 +10,12 @@ from ckanext.benap.helpers import ontology_helper, scheming_language_text_fallba
     package_notes_translated_fallback, field_translated_fallback, organisation_names_for_autocomplete, \
     get_translated_tags, scheming_language_text, format_datetime, get_translated_tag, get_translated_tag_with_name, \
     forum_url, filter_default_tags_only, getTranslatedVideoUrl, show_element, get_organization_by_id, benap_fluent_label, \
-    translate_organization_filter, is_user_sysAdmin, is_nap_checked, convert_validation_list_to_JSON, benap_get_organization_field
+    translate_organization_filter, is_user_sysAdmin, is_nap_checked, convert_validation_list_to_JSON, benap_get_organization_field_by_id, \
+    benap_get_organization_field_by_specified_field
 from ckanext.benap.util.forms import map_for_form_select
 from ckanext.benap.validators import phone_number_validator, \
     countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin, \
-    is_choice_null
+    is_choice_null, contact_point_org_fields_consistency_check
 from ckanext.benap.logic.auth.get import user_list
 
 
@@ -70,7 +71,8 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'benap_is_user_sysAdmin': is_user_sysAdmin,
             'benap_is_nap_checked':is_nap_checked,
             'benap_convert_validation_list_to_JSON': convert_validation_list_to_JSON,
-            'benap_get_organization_field': benap_get_organization_field
+            'benap_get_organization_field_by_id': benap_get_organization_field_by_id,
+            'benap_get_organization_field_by_specified_field': benap_get_organization_field_by_specified_field
         }
 
     # IValidators
@@ -82,7 +84,8 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'benap_is_after_start': is_after_start,
             'benap_https_validator': https_validator,
             'benap_modified_by_sysadmin': modified_by_sysadmin,
-            'benap_is_choice_null': is_choice_null
+            'benap_is_choice_null': is_choice_null,
+            'benap_contact_point_org_fields_consistency_check': contact_point_org_fields_consistency_check
         }
 
     # IAuthFunctions
@@ -122,12 +125,38 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
         return pkg_dict
 
     def before_view(self, pkg_dict):
+        # Remove 'agreement_declaration_nap' from the dictionary if it exists
         pkg_dict.pop('agreement_declaration_nap', None)
 
-        # Retrieve organization id of the dataset
-        org_id = pkg_dict.get('organization').get('id')
-        pkg_dict['publisher_url'] = benap_get_organization_field(org_id, 'do_website')
-        pkg_dict['publisher_email'] = benap_get_organization_field(org_id, 'do_email')
-        pkg_dict['publisher_telephone_number'] = benap_get_organization_field(org_id, 'do_tel')
+        # Get the organization ID associated with the dataset
+        org_id = pkg_dict.get('organization', {}).get('id')
+
+        # Define required organization fields to retrieve
+        fields = ['do_website', 'do_email', 'do_tel', 'country', 'administrative_area', 'postal_code', 'city',
+                  'street_address']
+
+        # Retrieve organization field values by ID and store them in a dictionary
+        values = {field: benap_get_organization_field_by_id(org_id, field) for field in fields}
+
+        # Update package dictionary with organization details
+        pkg_dict.update({
+            'publisher_url': values['do_website'],
+            'publisher_email': values['do_email'],
+            'publisher_telephone_number': values['do_tel'],
+            'publisher_country': values['country'],
+            'publisher_administrative_area': values['administrative_area'],
+            'publisher_postal_code': values['postal_code'],
+            'publisher_city': values['city'],
+            'publisher_street_address': values['street_address'],
+
+            # Combine address components into a nested dictionary for complete address details
+            'publisher_address': {
+                'street_address': values['street_address'],
+                'postal_code': values['postal_code'],
+                'city': values['city'],
+                'administrative_area': values['administrative_area'],
+                'country': values['country']
+            }
+        })
 
         return pkg_dict

--- a/ckanext/benap/validators.py
+++ b/ckanext/benap/validators.py
@@ -5,7 +5,8 @@ from ckan.logic.validators import Invalid
 from ckanext.scheming.validation import scheming_validator
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.navl.dictization_functions import Missing
-
+from ckanext.benap.helpers import (organisation_names_for_autocomplete, benap_get_organization_field_by_id,
+                                   benap_get_organization_field_by_specified_field)
 
 # pattern from http://phoneregex.com/
 phone_number_pattern = re.compile(
@@ -101,3 +102,29 @@ def is_choice_null(value):
     if isinstance(value, Missing) or value =='':
         return None
     return value
+
+def contact_point_org_fields_consistency_check(key, flattened_data, errors, context):
+    contact_point_name = flattened_data.get(('contact_point_name',))
+
+    if contact_point_name in organisation_names_for_autocomplete():
+
+        owner_org_id = flattened_data.get(('owner_org',))
+        owner_org_title = benap_get_organization_field_by_id(owner_org_id, 'title')
+
+        if owner_org_title == contact_point_name:
+            owner_org = owner_org_id
+        else:
+            owner_org = benap_get_organization_field_by_specified_field(contact_point_name, 'id','title')
+
+        if key == (u'contact_point_email',):
+            contact_point_email = flattened_data.get(('contact_point_email',))
+            publisher_email = benap_get_organization_field_by_id(owner_org, 'do_email')
+            if contact_point_email != publisher_email:
+                raise Invalid(
+                    _('The contact point email must match the contact point organization\'s email: {}').format(
+                        publisher_email))
+        else:
+            contact_point_phone = flattened_data.get(('contact_point_phone',))
+            publisher_telephone_number = benap_get_organization_field_by_id(owner_org, 'do_tel')
+            if contact_point_phone != publisher_telephone_number:
+                raise Invalid(_('The contact point telephone number must match the contact point organization\'s telephone number: {}').format(publisher_telephone_number))


### PR DESCRIPTION
Deze pr behandelt card 15, 24 en 25. Nieuwe adresvelden zijn aangemaakt (nested fields). Waarden van een organisatie worden automatisch genomen bij de metadata van een dataset. Contact point werd aangepast naar name, email en phone number (nested fields). Ook een validator werd hierbij geschreven om te kijken of de email en teloofnummer overeen komen met de organisatie wanneer het contact point een organisatie is. Ook de publisher/organization velden werden aangepast en heringedeeld zodanig dat ze de correct functionaliteit hebben voor mobilityDCAT-AP. Nu was dit niet correct. Soms was de publisher verschillend van de organisatie van een dataset.