### PR TITLE
card 28 - Contact Point Autofill

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -238,7 +238,7 @@
       "label": {
         "en": "Contact point",
         "fr": "Point de contact",
-        "nl": "contactpunt",
+        "nl": "Contactpunt",
         "de": "Kontaktpunkt"
       },
       "help_text": {
@@ -247,20 +247,17 @@
         "nl": "Het contactpunt van de metadata, verdeeld in drie velden: naam (verplicht), e-mail (verplicht) en telefoonnummer (optioneel).",
         "de": "Der Ansprechpartner der Metadaten, unterteilt in drei Felder: Name (verpflichtend), E-Mail (verpflichtend) und Telefonnummer (optional)."
       },
-      "form_snippet": "nested_field.html",
+      "form_snippet": "nested_field_with_autocomplete.html",
       "display_snippet": null,
       "nested_fields": [
         {
-            "field_name": "contact_point_name",
-            "form_snippet": "text_autocomplete.html"
+            "field_name": "contact_point_name"
         },
         {
-            "field_name": "contact_point_email",
-            "form_snippet": "text.html"
+            "field_name": "contact_point_email"
         },
         {
-            "field_name": "contact_point_phone",
-            "form_snippet": "text.html"
+            "field_name": "contact_point_tel"
         }
       ]
     },
@@ -290,10 +287,10 @@
         "de": "E-mail [Kontaktpunkt]"
       },
       "help_text": {
-        "en": "The email adress must contain @ and a dot.",
-        "fr": "L'adresse e-mail doit contenir @ et un point.",
-        "nl": "Het e-mailadres moet  @ en een punt inhouden.",
-        "de": "Die E-Mail muss  @ und einen Punkt beinhalten."
+          "en": "The email address must contain @ and a dot. The field will be automatically filled when the contact point is an organization.",
+          "fr": "L'adresse e-mail doit contenir @ et un point. Le champ sera automatiquement rempli lorsque le point de contact est une organisation.",
+          "nl": "Het e-mailadres moet @ en een punt inhouden. Het veld wordt automatisch ingevuld wanneer het contactpunt een organisatie is.",
+          "de": "Die E-Mail muss @ und einen Punkt beinhalten. Das Feld wird automatisch ausgefüllt, wenn der Kontaktpunkt eine Organisation ist."
       },
       "required": "true",
       "form_snippet": null,
@@ -302,7 +299,7 @@
       "validators": "email_validator not_empty benap_contact_point_org_fields_consistency_check"
     },
     {
-      "field_name": "contact_point_phone",
+      "field_name": "contact_point_tel",
       "label": {
         "en": "Telephone number [contact point]",
         "fr": "Numéro de téléphone [point de contact]",
@@ -310,11 +307,11 @@
         "de": "Telefonnummer [Kontaktpunkt]"
       },
       "help_text": {
-        "en": "The telephone number must start with the country prefix (e.g. \",+32\" for Belgium) and may only contain numbers from 0 to 9 besides the \"+\" sign.",
-        "fr": "Le numéro de téléphone doit commencer par le préfixe du pays (par ex. \"+32\" pour la Belgique) et ne peut contenir que des chiffres de 0 à 9 en plus du signe \"+\".",
-        "nl": "Het telefoonnummer moet met het netnummer van het land beginnen (bv. \"+32\" voor België) en kan naast de teken \"+\" alleen maar cijfers van 0 tot 9 inhouden.",
-        "de": "Die Telefonnummer muss mit der Vorwahl des Landes anfangen (zum B. \"+32\" für Belgien) und kann neben dem Zeichen \"+\" nur Zahlen von 0 bis 9 beinhalten."
-      },
+        "en": "The telephone number must start with the country prefix (e.g. \",+32\" for Belgium) and may only contain numbers from 0 to 9 besides the \"+\" sign. The field will be automatically filled when the contact point is an organization.",
+        "fr": "Le numéro de téléphone doit commencer par le préfixe du pays (par ex. \"+32\" pour la Belgique) et ne peut contenir que des chiffres de 0 à 9 en plus du signe \"+\". Le champ sera automatiquement rempli lorsque le point de contact est une organisation.",
+        "nl": "Het telefoonnummer moet met het netnummer van het land beginnen (bv. \"+32\" voor België) en kan naast de teken \"+\" alleen maar cijfers van 0 tot 9 inhouden. Het veld wordt automatisch ingevuld wanneer het contactpunt een organisatie is.",
+        "de": "Die Telefonnummer muss mit der Vorwahl des Landes anfangen (zum B. \"+32\" für Belgien) und kann neben dem Zeichen \"+\" nur Zahlen von 0 bis 9 beinhalten. Das Feld wird automatisch ausgefüllt, wenn der Kontaktpunkt eine Organisation ist."
+    },
       "form_placeholder": "+32XXXXXXXX",
       "form_snippet": null,
       "validators": "phone_number_validator benap_contact_point_org_fields_consistency_check"

--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -1423,3 +1423,36 @@ def benap_get_organization_field_by_specified_field(org_value, field_name, searc
 
     field_value = org_data.get(field_name)
     return field_value
+
+
+def benap_retrieve_org_title_tel_email():
+    """
+    Retrieves a list of organizations where the current user can create datasets,
+    including only the organization's title, telephone number, and email.
+    """
+    from ckantoolkit import h
+    user = toolkit.get_action(u'get_site_user')(
+        {
+            u'ignore_auth': True
+        },
+        {})
+    context = {u'user': user[u'name']}
+    available_orgs_for_user = [org['name'].encode("utf-8") for org in h.organizations_available('create_dataset')]
+    data = toolkit.get_action(u'organization_list')(context,
+                                                    {
+                                                        u'include_dataset_count': False,
+                                                        u'all_fields': True,
+                                                        u'include_users': False,
+                                                        u'include_groups': False,
+                                                        u'include_tags': False,
+                                                        u'include_followers': False,
+                                                        u'include_extras': True,
+                                                        u'organizations': available_orgs_for_user
+                                                    })
+    keys_to_keep = ["title", "do_tel", "do_email"]
+    filtered_data = [
+        {key: item.get(key) for key in keys_to_keep}
+        for item in data
+    ]
+    json_data = json.dumps(filtered_data, ensure_ascii=False)
+    return json_data

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -11,7 +11,7 @@ from ckanext.benap.helpers import ontology_helper, scheming_language_text_fallba
     get_translated_tags, scheming_language_text, format_datetime, get_translated_tag, get_translated_tag_with_name, \
     forum_url, filter_default_tags_only, getTranslatedVideoUrl, show_element, get_organization_by_id, benap_fluent_label, \
     translate_organization_filter, is_user_sysAdmin, is_nap_checked, convert_validation_list_to_JSON, benap_get_organization_field_by_id, \
-    benap_get_organization_field_by_specified_field
+    benap_get_organization_field_by_specified_field, benap_retrieve_org_title_tel_email
 from ckanext.benap.util.forms import map_for_form_select
 from ckanext.benap.validators import phone_number_validator, \
     countries_covered_belgium, is_after_start, https_validator, modified_by_sysadmin, \
@@ -72,7 +72,8 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'benap_is_nap_checked':is_nap_checked,
             'benap_convert_validation_list_to_JSON': convert_validation_list_to_JSON,
             'benap_get_organization_field_by_id': benap_get_organization_field_by_id,
-            'benap_get_organization_field_by_specified_field': benap_get_organization_field_by_specified_field
+            'benap_get_organization_field_by_specified_field': benap_get_organization_field_by_specified_field,
+            'benap_retrieve_org_title_tel_email': benap_retrieve_org_title_tel_email
         }
 
     # IValidators

--- a/ckanext/benap/validators.py
+++ b/ckanext/benap/validators.py
@@ -79,29 +79,30 @@ def https_validator(value, context):
 
 
 def modified_by_sysadmin(schema_value, package):
-     
-     user  = package.get("auth_user_obj")
-     #parse schema_value
-     trueValues = {"true"}
-     flag = False
+    user = package.get("auth_user_obj")
+    # parse schema_value
+    trueValues = {"true"}
+    flag = False
 
-     if isinstance(schema_value, str):
-         lowerValue = schema_value.strip().lower()
-         if lowerValue in trueValues:
-             flag == True
-    
-     if user is not None:
+    if isinstance(schema_value, str):
+        lowerValue = schema_value.strip().lower()
+        if lowerValue in trueValues:
+            flag == True
+
+    if user is not None:
         if not user.sysadmin and flag:
             raise Invalid(_('Modification must done by a system administrator'))
         else:
             return schema_value
-     else:
-         raise Invalid(_('Logged in one must be'))
-     
+    else:
+        raise Invalid(_('Logged in one must be'))
+
+
 def is_choice_null(value):
-    if isinstance(value, Missing) or value =='':
+    if isinstance(value, Missing) or value == '':
         return None
     return value
+
 
 def contact_point_org_fields_consistency_check(key, flattened_data, errors, context):
     contact_point_name = flattened_data.get(('contact_point_name',))
@@ -114,7 +115,7 @@ def contact_point_org_fields_consistency_check(key, flattened_data, errors, cont
         if owner_org_title == contact_point_name:
             owner_org = owner_org_id
         else:
-            owner_org = benap_get_organization_field_by_specified_field(contact_point_name, 'id','title')
+            owner_org = benap_get_organization_field_by_specified_field(contact_point_name, 'id', 'title')
 
         if key == (u'contact_point_email',):
             contact_point_email = flattened_data.get(('contact_point_email',))
@@ -124,7 +125,9 @@ def contact_point_org_fields_consistency_check(key, flattened_data, errors, cont
                     _('The contact point email must match the contact point organization\'s email: {}').format(
                         publisher_email))
         else:
-            contact_point_phone = flattened_data.get(('contact_point_phone',))
+            contact_point_tel = flattened_data.get(('contact_point_tel',))
             publisher_telephone_number = benap_get_organization_field_by_id(owner_org, 'do_tel')
-            if contact_point_phone != publisher_telephone_number:
-                raise Invalid(_('The contact point telephone number must match the contact point organization\'s telephone number: {}').format(publisher_telephone_number))
+            if contact_point_tel != publisher_telephone_number:
+                raise Invalid(
+                    _('The contact point telephone number must match the contact point organization\'s telephone number: {}').format(
+                        publisher_telephone_number))


### PR DESCRIPTION
Deze pr voegt een autofill functionaliteit toe aan de contact point fields. Javascript gedrag is toegevoegd dat de email en tel veld automatisch invult wanneer een organisatie wordt geselecteerd. Wanneer geen organisatie wordt ingevuld, zijn de velden email en tel vrije invulvelden.