### PR TITLE
adapt mmtis form choice label text

### DIFF
--- a/ckanext/benap/benap_schema_organization.json
+++ b/ckanext/benap/benap_schema_organization.json
@@ -356,14 +356,15 @@
       },
       "multi_help": "true",
       "preset": "multiple_radio_compliance",
+      "form_snippet": "html_radio.html",
       "choices": [
          {
           "value": "Y",
           "label": {
-              "en": "I hereby declare to be compliant to articles 3 to 8 of the European regulation (EU) 2017/1926.",
-              "fr": "Je déclare être en conformité avec les articles 3 à 8 du règlement délégué européen (UE) 2017/1926.",
-              "nl": "Ik verklaar voor deze dataset in overeenstemming te zijn met artikels 3 tot 8 van de Europese verordening (EU) 2017/1926.",
-              "de": "Hiermit erkläre ich, in Übereinstimmung mit den Artikeln 3 bis 8 der Europäischen Verordnung (EU) 2017/1926."
+              "en": "I hereby declare to be compliant to articles 3 to 8 of the European regulation (EU) 2017/1926 and its amendment <a target=\"_blank\"  href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202400490\">EU 2024/490</a>.",
+              "fr": "Je déclare être en conformité avec les articles 3 à 8 du règlement délégué européen (UE) 2017/1926 et son modification <a target=\"_blank\"  href=\"https://eur-lex.europa.eu/legal-content/FR/TXT/HTML/?uri=OJ:L_202400490\">EU 2024/490</a>.",
+              "nl": "Ik verklaar voor deze dataset in overeenstemming te zijn met artikels 3 tot 8 van de Europese verordening (EU) 2017/1926 en zijn wijziging <a target=\"_blank\"  href=\"https://eur-lex.europa.eu/legal-content/NL/TXT/HTML/?uri=OJ:L_202400490\">EU 2024/490</a>.",
+              "de": "Hiermit erkläre ich, in Übereinstimmung mit den Artikeln 3 bis 8 der Europäischen Verordnung (EU) 2017/1926 und seine Änderung <a target=\"_blank\" href=\"https://eur-lex.europa.eu/legal-content/DE/TXT/HTML/?uri=OJ:L_202400490\">EU 2024/490</a>."
             },
           "help_text": {
               "en": "For more information <a>click here</a>",

--- a/ckanext/benap/templates/scheming/form_snippets/html_radio.html
+++ b/ckanext/benap/templates/scheming/form_snippets/html_radio.html
@@ -1,0 +1,48 @@
+{# adapted from https://github.com/ckan/ckanext-scheming/blob/da2daad24b825dbe521325dee7e45d02ac6ec371/ckanext/scheming/templates/scheming/form_snippets/radio.html#L1 #}
+{# to allow html in radio choice label with "|safe" #}
+
+{% import 'macros/form.html' as form %}
+
+{%- set options=[] -%}
+{%- set form_restrict_choices_to=field.get('form_restrict_choices_to') -%}
+{%- if not h.scheming_field_required(field) or
+    field.get('form_include_blank_choice', false) -%}
+  {%- do options.append({'value': '', 'text': ''}) -%}
+{%- endif -%}
+{%- for c in h.scheming_field_choices(field) -%}
+  {%- if not form_restrict_choices_to or c.value in form_restrict_choices_to -%}
+    {%- do options.append({
+      'value': c.value|string,
+      'text': h.scheming_language_text(c.label) }) -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if field.get('sorted_choices') -%}
+  {%- set options = options|sort(case_sensitive=false, attribute='text') -%}
+{%- endif -%}
+{%- if data[field.field_name] is defined -%}
+  {%- set option_selected = data[field.field_name]|string -%}
+{%- else -%}
+  {%- set option_selected = None -%}
+{%- endif -%}
+
+{%- call form.input_block(
+    label=h.scheming_language_text(field.label),
+    classes=field.classes if 'classes' in field else ['control-medium'],
+    error=errors[field.field_name],
+    is_required=h.scheming_field_required(field)) -%}
+    <fieldset class="radio-group">
+      {%- for c in field.choices -%}
+        <div>
+          <label for="field-{{ field.field_name }}-{{ c.value }}">
+            <input id="field-{{ field.field_name }}-{{ c.value }}"
+                type="radio"
+                name="{{ field.field_name }}"
+                value="{{ c.value }}"
+                {{ "checked " if c.value == data[field.field_name] }} />
+            {{ h.scheming_language_text(c.label)|safe }}
+          </label>
+        </div>
+      {%- endfor -%}
+    </fieldset>
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{%- endcall -%}


### PR DESCRIPTION
## description

Text of DoC MMTIS to change:
- from: I hereby declare to be compliant to articles 3 to 8 of the European regulation (EU) 2017/1926.
- to: I hereby declare to be compliant to articles 3 to 8 of the European regulation (EU) 2017/1926 and its amendment [EU 2024/490](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202400490).

## implementation notes

The ckan scheming radio form template doesn't allow html in the label. Copied the radio component using `|safe` to keep html. Could also be implemented as a custom component entirely (with the copy text in the html).