### PR TITLE
fix validation for network_coverage

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -503,7 +503,7 @@
         "nl":"Netwerkdekking beschrijft het deel van het transportnetwerk dat door de geleverde inhoud wordt gedekt.",
         "de":"Netzabdeckung beschreibt den Teil des Verkehrsnetzes, der durch den gelieferten Inhalt abgedeckt wird."
       },
-      "validators":"benap_is_choice_null"
+      "validators":"scheming_multiple_choice benap_is_choice_null"
     },
     {
       "field_name": "reference_system",


### PR DESCRIPTION
The choices were not validated yet, so a value outside of the provided choices could be used instead.

Adds the scheming_multiple_choice validator to validate the choice specifically.


Issue description:
> Validator need to be added for field Network coverage (at dataset level)

> For this field, a restricted list of values (controlled vocabularies) is accepted. Thus, a validator has to be set in order to check and ensure users are providing an accepted value through CKAN API.

> Field Georeferencing method is also concerned for example.