### PR TITLE
final cleanup of ckan-core translation overwrites

### DIFF
--- a/ckanext/benap/i18n/ckan-translations-overwrite.pot
+++ b/ckanext/benap/i18n/ckan-translations-overwrite.pot
@@ -28,58 +28,16 @@ msgstr ""
 msgid "Sysadmin settings"
 msgstr ""
 
-msgid "Admin"
+#. fr, nl
+msgid "<p class=\"extra\">Please try another search.</p>"
 msgstr ""
 
-msgid "View profile"
+#. fr, nl, de
+msgid "<p id=\"search-error\"><strong>There was an error while "
+"searching.</strong> Please try again.</p>"
 msgstr ""
 
-msgid "Dashboard (%(num)d new item)"
-msgid_plural "Dashboard (%(num)d new items)"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "Dashboard"
-msgstr ""
-
-msgid "Settings"
-msgstr ""
-
-msgid "Log out"
-msgstr ""
-
-msgid "Organizations"
-msgstr ""
-
-msgid "Groups"
-msgstr ""
-
-msgid "Search"
-msgstr ""
-
-msgid "Search datasets..."
-msgstr ""
-
-msgid "Name Ascending"
-msgstr ""
-
-msgid "Name Descending"
-msgstr ""
-
-msgid "Order by"
-msgstr ""
-
-#: ckan/templates/snippets/search_form.html:83
-msgid " <p class=\"extra\">Please try another search.</p> "
-msgstr ""
-
-msgid "" " <p id=\"search-error\"><strong>There was an error while "
-"searching.</strong> Please try again.</p> "
-msgstr ""
-
-msgid "Activity from items that I'm following"
-msgstr ""
-
+#. fr, nl, de, en - remove first sentence
 msgid ""
 "The <i>data license</i> you select above"
 " only applies to the contents of "
@@ -92,379 +50,317 @@ msgid ""
 "Database License</a>."
 msgstr ""
 
-msgid "Why Sign Up?"
-msgstr ""
-
-msgid "Register for an Account"
-msgstr ""
-
-msgid "News feed"
-msgstr ""
-
-msgid "Go"
-msgstr ""
-
-msgid "There are no {facet_type} that match this search"
-msgstr ""
-
-msgid "Show Only Popular {facet_type}"
-msgstr ""
-
-msgid "Show More {facet_type}"
-msgstr ""
-
-msgid "Draft"
-msgstr ""
-
-msgid "View {organization_name}"
-msgstr ""
-
-msgid "0 Datasets"
-msgstr ""
-
-msgid "{num} Dataset"
-msgid_plural "{num} Datasets"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "Deleted"
-msgstr ""
-
-msgid "About"
-msgstr ""
-
-msgid "E.g. environment"
-msgstr ""
-
-msgid "Type"
-msgstr ""
-
-msgid "Welcome"
-msgstr ""
-
-msgid "CKAN API"
-msgstr ""
-
-msgid "Registration"
-msgstr ""
-
-msgid "Register"
-msgstr ""
-
-msgid "Forgot your password?"
-msgstr ""
-
-msgid "No problem, use our password recovery form to reset it."
-msgstr ""
-
-msgid "Forgotten your password?"
-msgstr ""
-
-msgid "Create an Account"
-msgstr ""
-
-msgid "Then sign right up, it only takes a minute."
-msgstr ""
-
-msgid "Need an Account?"
-msgstr ""
-
-msgid "My Organizations"
-msgstr ""
-
-msgid "My Datasets"
-msgstr ""
-
-msgid "Filter Results"
-msgstr ""
-
-msgid "Language"
-msgstr ""
-
-msgid "What's a resource?"
-msgstr ""
-
-msgid "Filters"
-msgstr ""
-
-msgid "Log in"
-msgstr ""
-
-msgid "Remove"
-msgstr ""
-
-msgid "UK Open Government Licence (OGL)"
-msgstr ""
-
-msgid "Unauthorized to create a group"
-msgstr ""
-
-msgid "Integrity Error"
-msgstr ""
-
-msgid "Group not found"
-msgstr ""
-
-msgid "Link"
-msgstr ""
-
-msgid "Link to a URL on the internet (you can also link to an API)"
-msgstr ""
-
-msgid "Upload"
-msgstr ""
-
-msgid "Remove"
-msgstr ""
-
-msgid "Image"
-msgstr ""
-
-msgid "Upload a file on your computer"
-msgstr ""
-
-msgid "URL"
-msgstr ""
-
-msgid "File"
-msgstr ""
-
-msgid "Tag \"%s\" length is less than minimum %s"
-msgstr ""
-
-msgid "Tag \"%s\" length is more than maximum %i"
-msgstr ""
-
-msgid "CKAN API"
-msgstr ""
-
-msgid "Welcome"
-msgstr ""
-
-msgid "Type"
-msgstr ""
-
-msgid "E.g. environment"
-msgstr ""
-
-msgid "Log in"
-msgstr ""
-
-msgid "Datasets"
-msgstr ""
-
-msgid "Members"
-msgstr ""
-
-msgid "About"
-msgstr ""
-
-msgid "Organization"
-msgstr ""
-
-msgid "Deleted"
-msgstr ""
-
-msgid "read more"
-msgstr ""
-
-msgid "There is no description for this organization"
-msgstr ""
-
-msgid "Followers"
-msgstr ""
-
-msgid "0 Datasets"
-msgstr ""
-
-msgid "View {organization_name}"
-msgstr ""
-
-msgid "Private"
-msgstr ""
-
-msgid "Draft"
-msgstr ""
-
-msgid "New view"
-msgstr ""
-
-msgid "Filters"
-msgstr ""
-
-msgid "Unfollow"
-msgstr ""
-
-msgid "Follow"
-msgstr ""
-
-msgid "What's a resource?"
-msgstr ""
-
-msgid "Format"
-msgstr ""
-
-msgid "Explore"
-msgstr ""
-
-msgid "Preview"
-msgstr ""
-
-msgid "More information"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Go to resource"
-msgstr ""
-
-msgid "Edit resource"
-msgstr ""
-
-msgid "Views"
-msgstr ""
-
-msgid "Clear Upload"
-msgstr ""
-
-msgid "Public"
-msgstr ""
-
-msgid "http://example.com/my-image.jpg"
-msgstr ""
-
-msgid "Image URL"
-msgstr ""
-
-msgid "Additional Information"
-msgstr ""
-
-msgid "Field"
-msgstr ""
-
-msgid "Value"
-msgstr ""
-
-msgid "Last updated"
-msgstr ""
-
-msgid "unknown"
-msgstr ""
-
-msgid "Created"
-msgstr ""
-
-msgid "State"
-msgstr ""
-
-msgid "The form contains invalid entries:"
-msgstr ""
-
-msgid "Show More {facet_type}"
-msgstr ""
-
-msgid "Show Only Popular {facet_type}"
-msgstr ""
-
-msgid "There are no {facet_type} that match this search"
-msgstr ""
-
-msgid "Language"
-msgstr ""
-
-msgid "Go"
-msgstr ""
-
-msgid "No License Provided"
-msgstr ""
-
-msgid "License"
-msgstr ""
-
-msgid "This dataset satisfies the Open Definition."
-msgstr ""
-
-msgid "Filter Results"
-msgstr ""
-
-msgid "News feed"
-msgstr ""
-
-msgid "My Datasets"
-msgstr ""
-
-msgid "My Organizations"
-msgstr ""
-
-msgid "You haven't created any datasets."
-msgstr ""
-
-msgid "Create one now?"
-msgstr ""
-
-msgid "Need an Account?"
-msgstr ""
-
-msgid "Then sign right up, it only takes a minute."
-msgstr ""
-
-msgid "Create an Account"
-msgstr ""
-
-msgid "Forgotten your password?"
-msgstr ""
-
-msgid "No problem, use our password recovery form to reset it."
-msgstr ""
-
-msgid "Forgot your password?"
-msgstr ""
-
-msgid "Register"
-msgstr ""
-
-msgid "Registration"
-msgstr ""
-
-msgid "Register for an Account"
-msgstr ""
-
-msgid "Why Sign Up?"
-msgstr ""
-
-msgid "Open ID"
-msgstr ""
-
-msgid "Username"
-msgstr ""
-
-msgid "Email"
-msgstr ""
-
-msgid "This means only you can see this"
-msgstr ""
-
-msgid "Member Since"
-msgstr ""
-
-msgid "Upload"
-msgstr ""
-
-msgid "Image"
-msgstr ""
-
-msgid "Upload a file on your computer"
-msgstr ""
-
-msgid "File"
-msgstr ""
-
-msgid "Visibility"
-msgstr ""
-
+#. nl, fr, de
 msgid "Please select the file to upload again"
 msgstr ""
 
+#. nl
 msgid "Edit"
+msgstr ""
+
+#. nl, fr
+msgid "Admin"
+msgstr ""
+
+#. nl, fr
+msgid "View profile"
+msgstr ""
+
+#. de
+msgid "Dashboard"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+#. de
+msgid "Log out"
+msgstr ""
+
+#. en, fr
+msgid "Organizations"
+msgstr ""
+
+#. fr
+msgid "Search"
+msgstr ""
+
+#. nl, fr, de
+msgid "Search datasets..."
+msgstr ""
+
+#. nl, de
+msgid "Name Ascending"
+msgstr ""
+
+#. nl, de
+msgid "Name Descending"
+msgstr ""
+
+#. nl, fr
+msgid "Order by"
+msgstr ""
+
+#. nl, fr, de
+msgid "Activity from items that I'm following"
+msgstr ""
+
+#. nl, fr, de
+msgid "Why Sign Up?"
+msgstr ""
+
+#. nl, fr, de
+msgid "Register for an Account"
+msgstr ""
+
+#. nl, fr, de
+msgid "News feed"
+msgstr ""
+
+#. fr, de
+msgid "Go"
+msgstr ""
+
+#. nl, fr, de
+msgid "There are no {facet_type} that match this search"
+msgstr ""
+
+#. nl, fr, de
+msgid "Show Only Popular {facet_type}"
+msgstr ""
+
+#. fr, de
+msgid "Show More {facet_type}"
+msgstr ""
+
+#. nl, de
+msgid "Draft"
+msgstr ""
+
+#. nl, en, fr, de
+msgid "View {organization_name}"
+msgstr ""
+
+#. fr, de
+msgid "0 Datasets"
+msgstr ""
+
+#. de
+msgid "Deleted"
+msgstr ""
+
+#. fr, de
+msgid "About"
+msgstr ""
+
+#. nl, fr, de
+msgid "E.g. environment"
+msgstr ""
+
+#. de
+msgid "Type"
+msgstr ""
+
+#. de
+msgid "Welcome"
+msgstr ""
+
+#. fr, de
+msgid "CKAN API"
+msgstr ""
+
+#. nl, en, fr
+msgid "Registration"
+msgstr ""
+
+#. nl, fr
+msgid "Register"
+msgstr ""
+
+#. nl, fr, de
+msgid "Forgot your password?"
+msgstr ""
+
+#. nl
+msgid "No problem, use our password recovery form to reset it."
+msgstr ""
+
+#. fr
+msgid "Forgotten your password?"
+msgstr ""
+
+#. nl
+msgid "Then sign right up, it only takes a minute."
+msgstr ""
+
+#. nl, fr
+msgid "Need an Account?"
+msgstr ""
+
+#. en, de
+msgid "My Organizations"
+msgstr ""
+
+#. en, de
+msgid "My Datasets"
+msgstr ""
+
+#. nl, fr
+msgid "Filter Results"
+msgstr ""
+
+#. fr
+msgid "What's a resource?"
+msgstr ""
+
+#. de
+msgid "Log in"
+msgstr ""
+
+#. en
+msgid "UK Open Government Licence (OGL)"
+msgstr ""
+
+#. nl, fr, de
+msgid "Link to a URL on the internet (you can also link to an API)"
+msgstr ""
+
+#. nl, fr
+msgid "Upload"
+msgstr ""
+
+#. nl, de
+msgid "Upload a file on your computer"
+msgstr ""
+
+#. fr, de
+msgid "CKAN API"
+msgstr ""
+
+#. de
+msgid "Welcome"
+msgstr ""
+
+#. de
+msgid "Type"
+msgstr ""
+
+#. nl, fr, de
+msgid "E.g. environment"
+msgstr ""
+
+#. de
+msgid "Log in"
+msgstr ""
+
+#. fr, de
+msgid "About"
+msgstr ""
+
+#. nl
+msgid "Organization"
+msgstr ""
+
+#. de
+msgid "Deleted"
+msgstr ""
+
+#. fr, de
+msgid "0 Datasets"
+msgstr ""
+
+#. nl, en, fr, de
+msgid "View {organization_name}"
+msgstr ""
+
+#. nl, fr
+msgid "Private"
+msgstr ""
+
+#. nl, de
+msgid "Draft"
+msgstr ""
+
+#. fr
+msgid "What's a resource?"
+msgstr ""
+
+#. nl, fr, de
+msgid "The form contains invalid entries:"
+msgstr ""
+
+#. fr, de
+msgid "Show More {facet_type}"
+msgstr ""
+
+#. nl, fr, de
+msgid "Show Only Popular {facet_type}"
+msgstr ""
+
+#. nl, fr, de
+msgid "There are no {facet_type} that match this search"
+msgstr ""
+
+#. fr, de
+msgid "Go"
+msgstr ""
+
+#. nl, fr
+msgid "Filter Results"
+msgstr ""
+
+#. nl, fr, de
+msgid "News feed"
+msgstr ""
+
+#. en, de
+msgid "My Datasets"
+msgstr ""
+
+#. en, de
+msgid "My Organizations"
+msgstr ""
+
+#. nl, fr
+msgid "Need an Account?"
+msgstr ""
+
+#. nl
+msgid "Then sign right up, it only takes a minute."
+msgstr ""
+
+#. fr
+msgid "Forgotten your password?"
+msgstr ""
+
+#. nl
+msgid "No problem, use our password recovery form to reset it."
+msgstr ""
+
+#. nl, fr, de
+msgid "Forgot your password?"
+msgstr ""
+
+#. nl, fr
+msgid "Register"
+msgstr ""
+
+#. nl, en, fr
+msgid "Registration"
+msgstr ""
+
+#. nl, fr, de
+msgid "Register for an Account"
+msgstr ""
+
+#. nl, fr, de
+msgid "Why Sign Up?"
+msgstr ""
+
+#. nl, fr
+msgid "Upload"
+msgstr ""
+
+#. nl, de
+msgid "Upload a file on your computer"
 msgstr ""

--- a/ckanext/benap/i18n/ckanext-benap.pot
+++ b/ckanext/benap/i18n/ckanext-benap.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ckanext-benap 2.0.4\n"
+"Project-Id-Version: ckanext-benap 4.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-21 10:49+0000\n"
+"POT-Creation-Date: 2025-08-22 13:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ckanext/benap/assets/js/scheming-doc_upload.js:82
 #: ckanext/benap/assets/js/scheming-logo_upload.js:76
 #: ckanext/benap/assets/js/scheming-proxy_upload.js:76
-#: ckanext/benap/templates/snippets/search_form.html:12
+#: ckanext/benap/templates/snippets/search_form.html:19
 msgid "Remove"
 msgstr ""
 
@@ -535,19 +535,19 @@ msgstr ""
 msgid "Popular Tags"
 msgstr ""
 
-#: ckanext/benap/templates/home/snippets/search.html:27
+#: ckanext/benap/templates/home/snippets/search.html:31
 msgid "ADD NEW DATA"
 msgstr ""
 
-#: ckanext/benap/templates/home/snippets/search.html:29
+#: ckanext/benap/templates/home/snippets/search.html:33
 msgid "Data providers can easily add data to the catalogue."
 msgstr ""
 
-#: ckanext/benap/templates/home/snippets/search.html:31
+#: ckanext/benap/templates/home/snippets/search.html:35
 msgid "Add Data"
 msgstr ""
 
-#: ckanext/benap/templates/home/snippets/search.html:33
+#: ckanext/benap/templates/home/snippets/search.html:37
 msgid "Log in"
 msgstr ""
 
@@ -570,7 +570,7 @@ msgid "Organization"
 msgstr ""
 
 #: ckanext/benap/templates/organization/snippets/info.html:19
-#: ckanext/benap/templates/package/read.html:21
+#: ckanext/benap/templates/package/read.html:20
 msgid "Deleted"
 msgstr ""
 
@@ -601,13 +601,13 @@ msgstr ""
 msgid "View {organization_name}"
 msgstr ""
 
-#: ckanext/benap/templates/package/read.html:8
+#: ckanext/benap/templates/package/read.html:7
 #: ckanext/benap/templates/scheming/form_snippets/organization.html:29
 #: ckanext/benap/templates/user/snippets/info.html:16
 msgid "Private"
 msgstr ""
 
-#: ckanext/benap/templates/package/read.html:18
+#: ckanext/benap/templates/package/read.html:17
 msgid "Draft"
 msgstr ""
 
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: ckanext/benap/templates/package/search.html:11
+#: ckanext/benap/templates/package/search.html:17
 msgid "close"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Signed"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:14
+#: ckanext/benap/templates/scheming/package/read.html:13
 #: ckanext/benap/templates/scheming/package/snippets/package_form.html:15
 #: ckanext/benap/templates/scheming/package/snippets/resource_form.html:15
 msgid ""
@@ -717,7 +717,7 @@ msgid ""
 "    might not be compatible with ckanext-scheming"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:34
+#: ckanext/benap/templates/scheming/package/read.html:33
 msgid "Transportation modes covered"
 msgstr ""
 
@@ -764,19 +764,19 @@ msgstr ""
 msgid "The form contains invalid entries:"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:6
+#: ckanext/benap/templates/snippets/facet_list.html:5
 msgid "Transportation modes"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:50
+#: ckanext/benap/templates/snippets/facet_list.html:40
 msgid "Show More {facet_type}"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:53
+#: ckanext/benap/templates/snippets/facet_list.html:43
 msgid "Show Only Popular {facet_type}"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:57
+#: ckanext/benap/templates/snippets/facet_list.html:47
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "This dataset has no description"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/search_form.html:17
+#: ckanext/benap/templates/snippets/search_form.html:26
 msgid "Filter Results"
 msgstr ""
 

--- a/ckanext/benap/i18n/de/LC_MESSAGES/ckanext-benap.po
+++ b/ckanext/benap/i18n/de/LC_MESSAGES/ckanext-benap.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-benap 0.0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-21 10:49+0000\n"
+"POT-Creation-Date: 2025-08-22 13:44+0000\n"
 "PO-Revision-Date: 2019-09-20 17:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -19,6 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.15.0\n"
 
+#. nl, fr, de
 #: ckanext/benap/assets/js/scheming-doc_upload.js:78
 #: ckanext/benap/assets/js/scheming-logo_upload.js:72
 #: ckanext/benap/assets/js/scheming-proxy_upload.js:72
@@ -514,21 +515,21 @@ msgstr "z.B. Carsharing, Zug, Fahrradvermietung, usw."
 msgid "Popular Tags"
 msgstr "Frequente Tags"
 
-#: ckanext/benap/templates/home/snippets/search.html:27
+#: ckanext/benap/templates/home/snippets/search.html:31
 msgid "ADD NEW DATA"
 msgstr "Datensätze und Dienste hinzufügen"
 
-#: ckanext/benap/templates/home/snippets/search.html:29
+#: ckanext/benap/templates/home/snippets/search.html:33
 msgid "Data providers can easily add data to the catalogue."
 msgstr ""
 "Datenanbieter können auf einfache Wiese Datenstäze und Dienste auf dem "
 "NAP ITS registrieren."
 
-#: ckanext/benap/templates/home/snippets/search.html:31
+#: ckanext/benap/templates/home/snippets/search.html:35
 msgid "Add Data"
 msgstr "Daten hinzufügen"
 
-#: ckanext/benap/templates/package/search.html:11
+#: ckanext/benap/templates/package/search.html:17
 msgid "close"
 msgstr "schließen"
 
@@ -564,7 +565,7 @@ msgstr ""
 msgid "Signed"
 msgstr "Unterzeichnet"
 
-#: ckanext/benap/templates/scheming/package/read.html:14
+#: ckanext/benap/templates/scheming/package/read.html:13
 #: ckanext/benap/templates/scheming/package/snippets/package_form.html:15
 #: ckanext/benap/templates/scheming/package/snippets/resource_form.html:15
 msgid ""
@@ -572,7 +573,7 @@ msgid ""
 "    might not be compatible with ckanext-scheming"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:34
+#: ckanext/benap/templates/scheming/package/read.html:33
 msgid "Transportation modes covered"
 msgstr "Transportarten abgedeckt"
 
@@ -590,7 +591,7 @@ msgctxt "Status"
 msgid "State"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:6
+#: ckanext/benap/templates/snippets/facet_list.html:5
 msgid "Transportation modes"
 msgstr "Transportmittel"
 
@@ -664,60 +665,19 @@ msgstr ""
 msgid "Sysadmin settings"
 msgstr "Parameter des Systemadministrators"
 
-msgid "Admin"
-msgstr "Administrator"
-
-msgid "View profile"
-msgstr "Profil ansehen"
-
-#, python-format
-msgid "Dashboard (%(num)d new item)"
-msgid_plural "Dashboard (%(num)d new items)"
-msgstr[0] "Dashboard (%(num)d neuer Punkt)"
-msgstr[1] "Dashboard (%(num)d neue Punkte)"
-
-msgid "Dashboard"
-msgstr "Dashboard"
-
-msgid "Settings"
-msgstr "Parameter"
-
-msgid "Log out"
-msgstr "Abmeldung"
-
-msgid "Organizations"
-msgstr "Organisationen"
-
-msgid "Groups"
-msgstr "Gruppen"
-
-msgid "Search"
-msgstr "Suche"
-
-msgid "Search datasets..."
-msgstr "Datensätze durchsuchen..."
-
-msgid "Name Ascending"
-msgstr "Name Aufsteigend"
-
-msgid "Name Descending"
-msgstr "Name Absteigend"
-
-msgid "Order by"
-msgstr "Sortieren nach"
-
-#: ckan/templates/snippets/search_form.html:83
-msgid " <p class=\"extra\">Please try another search.</p> "
+#. fr, nl
+msgid "<p class=\"extra\">Please try another search.</p>"
 msgstr ""
 
+#. fr, nl, de
 msgid ""
-" <p id=\"search-error\"><strong>There was an error while "
-"searching.</strong> Please try again.</p> "
+"<p id=\"search-error\"><strong>There was an error while "
+"searching.</strong> Please try again.</p>"
 msgstr ""
+"<p id=\"search-error\"><strong>Es ist ein Fehler bei der Suche "
+"aufgetreten.</strong> Bitte versuchen Sie es erneut.</p>"
 
-msgid "Activity from items that I'm following"
-msgstr "Aktivität von Elementen, denen ich folge"
-
+#. fr, nl, de, en - remove first sentence
 msgid ""
 "The <i>data license</i> you select above only applies to the contents of "
 "any resource files that you add to this dataset. By submitting this form,"
@@ -730,276 +690,199 @@ msgstr ""
 "unter der <a href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Open "
 "Database License</a> zu veröffentlichen."
 
+#. nl
+msgid "Edit"
+msgstr ""
+
+#. nl, fr
+msgid "Admin"
+msgstr ""
+
+#. nl, fr
+msgid "View profile"
+msgstr ""
+
+#. de
+msgid "Dashboard"
+msgstr "Dashboard"
+
+msgid "Settings"
+msgstr "Parameter"
+
+#. de
+msgid "Log out"
+msgstr "Abmeldung"
+
+#. en, fr
+msgid "Organizations"
+msgstr ""
+
+#. fr
+msgid "Search"
+msgstr ""
+
+#. nl, fr, de
+msgid "Search datasets..."
+msgstr "Datensätze durchsuchen..."
+
+#. nl, de
+msgid "Name Ascending"
+msgstr "Name Aufsteigend"
+
+#. nl, de
+msgid "Name Descending"
+msgstr "Name Absteigend"
+
+#. nl, fr
+msgid "Order by"
+msgstr ""
+
+#. nl, fr, de
+msgid "Activity from items that I'm following"
+msgstr "Aktivität von Elementen, denen ich folge"
+
+#. nl, fr, de
 msgid "Why Sign Up?"
 msgstr "Warum anmelden?"
 
+#. nl, fr, de
 msgid "Register for an Account"
 msgstr "Registrieren Sie sich für ein Konto"
 
+#. nl, fr, de
 msgid "News feed"
 msgstr "Neuigkeiten"
 
+#. fr, de
 msgid "Go"
 msgstr "Gehen"
 
+#. nl, fr, de
 msgid "There are no {facet_type} that match this search"
 msgstr "Es gibt keine {facet_type}, die dieser Suche entsprechen"
 
+#. nl, fr, de
 msgid "Show Only Popular {facet_type}"
 msgstr "Beliebte"
 
+#. fr, de
 msgid "Show More {facet_type}"
 msgstr "Mehr anzeigen {facet_type}"
 
+#. nl, de
 msgid "Draft"
 msgstr "Entworf"
 
+#. nl, en, fr, de
 #, fuzzy
 msgid "View {organization_name}"
 msgstr "meine Organisationen"
 
+#. fr, de
 #, fuzzy
 msgid "0 Datasets"
 msgstr "0 Datensätze"
 
-msgid "{num} Dataset"
-msgid_plural "{num} Datasets"
-msgstr[0] "{num} Datensätz"
-msgstr[1] "{num} Datensätze"
-
+#. de
 msgid "Deleted"
 msgstr "gelöscht"
 
+#. fr, de
 msgid "About"
 msgstr "Über"
 
+#. nl, fr, de
 msgid "E.g. environment"
 msgstr "Zum B. Umwelt"
 
+#. de
 msgid "Type"
 msgstr "Art"
 
+#. de
 msgid "Welcome"
 msgstr "Wilkommen"
 
+#. fr, de
 msgid "CKAN API"
 msgstr "CKAN API"
 
+#. nl, en, fr
 msgid "Registration"
-msgstr "Registrierung"
+msgstr ""
 
+#. nl, fr
 msgid "Register"
-msgstr "Registrieren"
+msgstr ""
 
+#. nl, fr, de
 msgid "Forgot your password?"
 msgstr "Haben Sie Ihr Kennwort vergessen?"
 
+#. nl
 msgid "No problem, use our password recovery form to reset it."
-msgstr "Kein Problem, nutzen Sie unser Formular um Ihr Passwort zurückzusetzen."
+msgstr ""
 
+#. fr
 msgid "Forgotten your password?"
-msgstr "Haben Sie Ihr Kennwort vergessen?"
+msgstr ""
 
-msgid "Create an Account"
-msgstr "Erstelle ein Benutzerkonto"
-
+#. nl
 msgid "Then sign right up, it only takes a minute."
-msgstr "Dann registrieren Sie sich, es dauert nur eine Minute."
+msgstr ""
 
+#. nl, fr
 msgid "Need an Account?"
-msgstr "Benötigen Sie ein Benutzerkonto?"
+msgstr ""
 
+#. en, de
 msgid "My Organizations"
 msgstr "meine Organisationen"
 
+#. en, de
 #, fuzzy
 msgid "My Datasets"
 msgstr "meine Datensätze"
 
+#. nl, fr
 msgid "Filter Results"
-msgstr "Ergebnisse filtern"
+msgstr ""
 
-msgid "Language"
-msgstr "Sprache"
-
+#. fr
 msgid "What's a resource?"
-msgstr "Was ist eine Ressource?"
+msgstr ""
 
-msgid "Filters"
-msgstr "Filter"
-
+#. de
 msgid "Log in"
 msgstr "Anmeldung"
 
-msgid "Remove"
-msgstr "Entfernen"
-
+#. en
 msgid "UK Open Government Licence (OGL)"
 msgstr ""
 
-msgid "Unauthorized to create a group"
-msgstr ""
-
-msgid "Integrity Error"
-msgstr ""
-
-msgid "Group not found"
-msgstr ""
-
-msgid "Link"
-msgstr ""
-
+#. nl, fr, de
 msgid "Link to a URL on the internet (you can also link to an API)"
 msgstr ""
 "Link zu einer URL auf der Website (Sie können auch einen Link zu einer "
 "API angeben)"
 
+#. nl, fr
 msgid "Upload"
-msgstr "Hochladen"
+msgstr ""
 
-msgid "Image"
-msgstr "Bild"
-
+#. nl, de
 msgid "Upload a file on your computer"
 msgstr "Laden Sie eine Datei auf ihren Computer hoch"
 
-msgid "URL"
-msgstr ""
-
-msgid "File"
-msgstr "Datei"
-
-#, python-format
-msgid "Tag \"%s\" length is less than minimum %s"
-msgstr ""
-
-#, python-format
-msgid "Tag \"%s\" length is more than maximum %i"
-msgstr ""
-
-msgid "Datasets"
-msgstr "Datensätze"
-
-msgid "Members"
-msgstr ""
-
+#. nl
 msgid "Organization"
 msgstr ""
 
-msgid "read more"
-msgstr ""
-
-msgid "There is no description for this organization"
-msgstr ""
-
-msgid "Followers"
-msgstr ""
-
+#. nl, fr
 msgid "Private"
-msgstr "Privat"
-
-msgid "New view"
 msgstr ""
 
-msgid "Unfollow"
-msgstr ""
-
-msgid "Follow"
-msgstr ""
-
-msgid "Format"
-msgstr ""
-
-msgid "Explore"
-msgstr ""
-
-msgid "Preview"
-msgstr ""
-
-msgid "More information"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Go to resource"
-msgstr ""
-
-msgid "Edit resource"
-msgstr ""
-
-msgid "Views"
-msgstr ""
-
-msgid "Clear Upload"
-msgstr ""
-
-msgid "Public"
-msgstr ""
-
-msgid "http://example.com/my-image.jpg"
-msgstr ""
-
-msgid "Image URL"
-msgstr ""
-
-msgid "Additional Information"
-msgstr ""
-
-msgid "Field"
-msgstr ""
-
-msgid "Value"
-msgstr ""
-
-msgid "Last updated"
-msgstr ""
-
-msgid "unknown"
-msgstr ""
-
-msgid "Created"
-msgstr ""
-
-msgid "State"
-msgstr ""
-
+#. nl, fr, de
 msgid "The form contains invalid entries:"
 msgstr "Das Formular enthält ungültige Einträge"
-
-msgid "No License Provided"
-msgstr ""
-
-msgid "License"
-msgstr ""
-
-msgid "This dataset satisfies the Open Definition."
-msgstr ""
-
-msgid "You haven't created any datasets."
-msgstr ""
-
-msgid "Create one now?"
-msgstr ""
-
-msgid "Open ID"
-msgstr ""
-
-msgid "Username"
-msgstr ""
-
-msgid "Email"
-msgstr ""
-
-msgid "This means only you can see this"
-msgstr ""
-
-msgid "Member Since"
-msgstr ""
-
-msgid "Visibility"
-msgstr "Sichtbarkeit"
-
-msgid "Edit"
-msgstr ""
 

--- a/ckanext/benap/i18n/en/LC_MESSAGES/ckanext-benap.po
+++ b/ckanext/benap/i18n/en/LC_MESSAGES/ckanext-benap.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-benap 0.0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-21 10:49+0000\n"
+"POT-Creation-Date: 2025-08-22 13:44+0000\n"
 "PO-Revision-Date: 2019-09-20 17:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -19,6 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.15.0\n"
 
+#. nl, fr, de
 #: ckanext/benap/assets/js/scheming-doc_upload.js:78
 #: ckanext/benap/assets/js/scheming-logo_upload.js:72
 #: ckanext/benap/assets/js/scheming-proxy_upload.js:72
@@ -505,19 +506,19 @@ msgstr "e.g. car sharing, train, bike hire,…"
 msgid "Popular Tags"
 msgstr "Popular Tags"
 
-#: ckanext/benap/templates/home/snippets/search.html:27
+#: ckanext/benap/templates/home/snippets/search.html:31
 msgid "ADD NEW DATA"
 msgstr "Add datasets and services"
 
-#: ckanext/benap/templates/home/snippets/search.html:29
+#: ckanext/benap/templates/home/snippets/search.html:33
 msgid "Data providers can easily add data to the catalogue."
 msgstr "Data providers can easily register datasets and services on the NAP ITS."
 
-#: ckanext/benap/templates/home/snippets/search.html:31
+#: ckanext/benap/templates/home/snippets/search.html:35
 msgid "Add Data"
 msgstr "Add Data"
 
-#: ckanext/benap/templates/package/search.html:11
+#: ckanext/benap/templates/package/search.html:17
 msgid "close"
 msgstr ""
 
@@ -551,7 +552,7 @@ msgstr ""
 msgid "Signed"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:14
+#: ckanext/benap/templates/scheming/package/read.html:13
 #: ckanext/benap/templates/scheming/package/snippets/package_form.html:15
 #: ckanext/benap/templates/scheming/package/snippets/resource_form.html:15
 msgid ""
@@ -559,7 +560,7 @@ msgid ""
 "    might not be compatible with ckanext-scheming"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:34
+#: ckanext/benap/templates/scheming/package/read.html:33
 msgid "Transportation modes covered"
 msgstr "Transportation modes covered"
 
@@ -577,7 +578,7 @@ msgctxt "Status"
 msgid "State"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:6
+#: ckanext/benap/templates/snippets/facet_list.html:5
 msgid "Transportation modes"
 msgstr ""
 
@@ -647,60 +648,17 @@ msgstr ""
 msgid "Sysadmin settings"
 msgstr "Sysadmin settings"
 
-msgid "Admin"
-msgstr "Admin"
-
-msgid "View profile"
-msgstr "View profile"
-
-#, python-format
-msgid "Dashboard (%(num)d new item)"
-msgid_plural "Dashboard (%(num)d new items)"
-msgstr[0] "Dashboard (%(num)d new item)"
-msgstr[1] "Dashboard (%(num)d new items)"
-
-msgid "Dashboard"
-msgstr "Dashboard"
-
-msgid "Settings"
-msgstr "Settings"
-
-msgid "Log out"
-msgstr "Log out"
-
-msgid "Organizations"
-msgstr "Organizations"
-
-msgid "Groups"
-msgstr "Groups"
-
-msgid "Search"
-msgstr "Search"
-
-msgid "Search datasets..."
+#. fr, nl
+msgid "<p class=\"extra\">Please try another search.</p>"
 msgstr ""
 
-msgid "Name Ascending"
-msgstr "Name Ascending"
-
-msgid "Name Descending"
-msgstr "Name Descending"
-
-msgid "Order by"
-msgstr "Order by"
-
-#: ckan/templates/snippets/search_form.html:83
-msgid " <p class=\"extra\">Please try another search.</p> "
-msgstr ""
-
+#. fr, nl, de
 msgid ""
-" <p id=\"search-error\"><strong>There was an error while "
-"searching.</strong> Please try again.</p> "
+"<p id=\"search-error\"><strong>There was an error while "
+"searching.</strong> Please try again.</p>"
 msgstr ""
 
-msgid "Activity from items that I'm following"
-msgstr "Activity from items that I'm following"
-
+#. fr, nl, de, en - remove first sentence
 msgid ""
 "The <i>data license</i> you select above only applies to the contents of "
 "any resource files that you add to this dataset. By submitting this form,"
@@ -714,276 +672,198 @@ msgstr ""
 "href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Open Database "
 "License</a>."
 
+#. nl
+msgid "Edit"
+msgstr ""
+
+#. nl, fr
+msgid "Admin"
+msgstr ""
+
+#. nl, fr
+msgid "View profile"
+msgstr ""
+
+#. de
+msgid "Dashboard"
+msgstr ""
+
+msgid "Settings"
+msgstr "Settings"
+
+#. de
+msgid "Log out"
+msgstr ""
+
+#. en, fr
+msgid "Organizations"
+msgstr "Organizations"
+
+#. fr
+msgid "Search"
+msgstr ""
+
+#. nl, fr, de
+msgid "Search datasets..."
+msgstr ""
+
+#. nl, de
+msgid "Name Ascending"
+msgstr ""
+
+#. nl, de
+msgid "Name Descending"
+msgstr ""
+
+#. nl, fr
+msgid "Order by"
+msgstr ""
+
+#. nl, fr, de
+msgid "Activity from items that I'm following"
+msgstr ""
+
+#. nl, fr, de
 msgid "Why Sign Up?"
-msgstr "Why Sign Up?"
+msgstr ""
 
+#. nl, fr, de
 msgid "Register for an Account"
-msgstr "Register for an Account"
+msgstr ""
 
+#. nl, fr, de
 msgid "News feed"
-msgstr "News feed"
+msgstr ""
 
+#. fr, de
 msgid "Go"
-msgstr "Go"
+msgstr ""
 
+#. nl, fr, de
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 
+#. nl, fr, de
 msgid "Show Only Popular {facet_type}"
 msgstr ""
 
+#. fr, de
 msgid "Show More {facet_type}"
 msgstr ""
 
+#. nl, de
 msgid "Draft"
-msgstr "Draft"
+msgstr ""
 
+#. nl, en, fr, de
 #, fuzzy
 msgid "View {organization_name}"
 msgstr "Organizations"
 
+#. fr, de
 #, fuzzy
 msgid "0 Datasets"
 msgstr "0 Datasets"
 
-msgid "{num} Dataset"
-msgid_plural "{num} Datasets"
-msgstr[0] "{num} Dataset"
-msgstr[1] "{num} Datasets"
-
+#. de
 msgid "Deleted"
-msgstr "Deleted"
+msgstr ""
 
+#. fr, de
 msgid "About"
-msgstr "About"
+msgstr ""
 
+#. nl, fr, de
 msgid "E.g. environment"
-msgstr "E.g. environment"
+msgstr ""
 
+#. de
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
+#. de
 msgid "Welcome"
-msgstr "Welcome"
+msgstr ""
 
+#. fr, de
 msgid "CKAN API"
-msgstr "CKAN API"
+msgstr ""
 
+#. nl, en, fr
 #, fuzzy
 msgid "Registration"
 msgstr "Organizations"
 
+#. nl, fr
 msgid "Register"
-msgstr "Register"
+msgstr ""
 
+#. nl, fr, de
 msgid "Forgot your password?"
-msgstr "Forgot your password?"
+msgstr ""
 
+#. nl
 msgid "No problem, use our password recovery form to reset it."
-msgstr "No problem, use our password recovery form to reset it."
+msgstr ""
 
+#. fr
 msgid "Forgotten your password?"
-msgstr "Forgotten your password?"
+msgstr ""
 
-msgid "Create an Account"
-msgstr "Create an Account"
-
+#. nl
 msgid "Then sign right up, it only takes a minute."
-msgstr "Then sign right up, it only takes a minute."
+msgstr ""
 
+#. nl, fr
 msgid "Need an Account?"
-msgstr "Need an Account?"
+msgstr ""
 
+#. en, de
 #, fuzzy
 msgid "My Organizations"
 msgstr "Organizations"
 
+#. en, de
 #, fuzzy
 msgid "My Datasets"
 msgstr "Datasets"
 
+#. nl, fr
 msgid "Filter Results"
 msgstr ""
 
-msgid "Language"
-msgstr "Language"
-
+#. fr
 msgid "What's a resource?"
-msgstr "What's a resource?"
-
-msgid "Filters"
 msgstr ""
 
+#. de
 msgid "Log in"
-msgstr "Log in"
-
-msgid "Remove"
 msgstr ""
 
+#. en
 msgid "UK Open Government Licence (OGL)"
 msgstr "UK Open Government License (OGL)"
 
-msgid "Unauthorized to create a group"
-msgstr ""
-
-msgid "Integrity Error"
-msgstr ""
-
-msgid "Group not found"
-msgstr ""
-
-msgid "Link"
-msgstr ""
-
+#. nl, fr, de
 msgid "Link to a URL on the internet (you can also link to an API)"
 msgstr ""
 
+#. nl, fr
 msgid "Upload"
 msgstr ""
 
-msgid "Image"
-msgstr ""
-
+#. nl, de
 msgid "Upload a file on your computer"
 msgstr ""
 
-msgid "URL"
-msgstr ""
-
-msgid "File"
-msgstr ""
-
-#, python-format
-msgid "Tag \"%s\" length is less than minimum %s"
-msgstr ""
-
-#, python-format
-msgid "Tag \"%s\" length is more than maximum %i"
-msgstr ""
-
-msgid "Datasets"
-msgstr "Datasets"
-
-msgid "Members"
-msgstr ""
-
+#. nl
 msgid "Organization"
 msgstr ""
 
-msgid "read more"
-msgstr ""
-
-msgid "There is no description for this organization"
-msgstr ""
-
-msgid "Followers"
-msgstr ""
-
+#. nl, fr
 msgid "Private"
-msgstr "Private"
-
-msgid "New view"
 msgstr ""
 
-msgid "Unfollow"
-msgstr ""
-
-msgid "Follow"
-msgstr ""
-
-msgid "Format"
-msgstr ""
-
-msgid "Explore"
-msgstr ""
-
-msgid "Preview"
-msgstr ""
-
-msgid "More information"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Go to resource"
-msgstr ""
-
-msgid "Edit resource"
-msgstr ""
-
-msgid "Views"
-msgstr ""
-
-msgid "Clear Upload"
-msgstr ""
-
-msgid "Public"
-msgstr ""
-
-msgid "http://example.com/my-image.jpg"
-msgstr ""
-
-msgid "Image URL"
-msgstr ""
-
-msgid "Additional Information"
-msgstr ""
-
-msgid "Field"
-msgstr ""
-
-msgid "Value"
-msgstr ""
-
-msgid "Last updated"
-msgstr ""
-
-msgid "unknown"
-msgstr ""
-
-msgid "Created"
-msgstr ""
-
-msgid "State"
-msgstr ""
-
+#. nl, fr, de
 msgid "The form contains invalid entries:"
 msgstr ""
-
-msgid "No License Provided"
-msgstr ""
-
-msgid "License"
-msgstr ""
-
-msgid "This dataset satisfies the Open Definition."
-msgstr ""
-
-msgid "You haven't created any datasets."
-msgstr ""
-
-msgid "Create one now?"
-msgstr ""
-
-msgid "Open ID"
-msgstr ""
-
-msgid "Username"
-msgstr ""
-
-msgid "Email"
-msgstr ""
-
-msgid "This means only you can see this"
-msgstr ""
-
-msgid "Member Since"
-msgstr ""
-
-msgid "Visibility"
-msgstr ""
-
-msgid "Edit"
-msgstr ""
-

--- a/ckanext/benap/i18n/fr/LC_MESSAGES/ckanext-benap.po
+++ b/ckanext/benap/i18n/fr/LC_MESSAGES/ckanext-benap.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-benap 0.0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-21 10:49+0000\n"
+"POT-Creation-Date: 2025-08-22 13:44+0000\n"
 "PO-Revision-Date: 2019-10-14 16:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -19,6 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.15.0\n"
 
+#. nl, fr, de
 #: ckanext/benap/assets/js/scheming-doc_upload.js:78
 #: ckanext/benap/assets/js/scheming-logo_upload.js:72
 #: ckanext/benap/assets/js/scheming-proxy_upload.js:72
@@ -511,21 +512,21 @@ msgstr "ex. autopartage, train, location de vélos, etc."
 msgid "Popular Tags"
 msgstr "Tags fréquents"
 
-#: ckanext/benap/templates/home/snippets/search.html:27
+#: ckanext/benap/templates/home/snippets/search.html:31
 msgid "ADD NEW DATA"
 msgstr "Ajouter des jeux de données et services"
 
-#: ckanext/benap/templates/home/snippets/search.html:29
+#: ckanext/benap/templates/home/snippets/search.html:33
 msgid "Data providers can easily add data to the catalogue."
 msgstr ""
 "Les fournisseurs de données peuvent facilement enregistrer des données et"
 " des services sur le NAP ITS."
 
-#: ckanext/benap/templates/home/snippets/search.html:31
+#: ckanext/benap/templates/home/snippets/search.html:35
 msgid "Add Data"
 msgstr "Ajouter données"
 
-#: ckanext/benap/templates/package/search.html:11
+#: ckanext/benap/templates/package/search.html:17
 msgid "close"
 msgstr "fermer"
 
@@ -560,7 +561,7 @@ msgstr ""
 msgid "Signed"
 msgstr "Signé"
 
-#: ckanext/benap/templates/scheming/package/read.html:14
+#: ckanext/benap/templates/scheming/package/read.html:13
 #: ckanext/benap/templates/scheming/package/snippets/package_form.html:15
 #: ckanext/benap/templates/scheming/package/snippets/resource_form.html:15
 msgid ""
@@ -568,7 +569,7 @@ msgid ""
 "    might not be compatible with ckanext-scheming"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:34
+#: ckanext/benap/templates/scheming/package/read.html:33
 msgid "Transportation modes covered"
 msgstr "Modes de transport couverts"
 
@@ -586,7 +587,7 @@ msgctxt "Status"
 msgid "State"
 msgstr ""
 
-#: ckanext/benap/templates/snippets/facet_list.html:6
+#: ckanext/benap/templates/snippets/facet_list.html:5
 msgid "Transportation modes"
 msgstr "Modes de transport"
 
@@ -659,60 +660,19 @@ msgstr ""
 msgid "Sysadmin settings"
 msgstr "Paramètres de l'administrateur système"
 
-msgid "Admin"
-msgstr "Admin"
+#. fr, nl
+msgid "<p class=\"extra\">Please try another search.</p>"
+msgstr "<p class=\"extra\">Veuillez essayer une autre recherche.</p>"
 
-msgid "View profile"
-msgstr "Voir profil"
-
-#, python-format
-msgid "Dashboard (%(num)d new item)"
-msgid_plural "Dashboard (%(num)d new items)"
-msgstr[0] "Tableau de bord (%(num)d nouvel élément"
-msgstr[1] "Tableau de bord (%(num)d nouveaux éléments"
-
-msgid "Dashboard"
-msgstr "Tableau de bord"
-
-msgid "Settings"
-msgstr "Paramètres"
-
-msgid "Log out"
-msgstr "Déconnexion"
-
-msgid "Organizations"
-msgstr "Les organisations"
-
-msgid "Groups"
-msgstr "Groupes"
-
-msgid "Search"
-msgstr "Recherche"
-
-msgid "Search datasets..."
-msgstr "Recherche des ensembles de données..."
-
-msgid "Name Ascending"
-msgstr "Nom croissant"
-
-msgid "Name Descending"
-msgstr "Nom décroissant"
-
-msgid "Order by"
-msgstr "Ordre par"
-
-#: ckan/templates/snippets/search_form.html:83
-msgid " <p class=\"extra\">Please try another search.</p> "
-msgstr ""
-
+#. fr, nl, de
 msgid ""
-" <p id=\"search-error\"><strong>There was an error while "
-"searching.</strong> Please try again.</p> "
+"<p id=\"search-error\"><strong>There was an error while "
+"searching.</strong> Please try again.</p>"
 msgstr ""
+"<p id=\"search-error\"><strong>Une erreur s'est produite lors de la "
+"recherche.</strong> Veuillez réessayer.</p>"
 
-msgid "Activity from items that I'm following"
-msgstr "Activité à partir d'éléments que je suis"
-
+#. fr, nl, de, en - remove first sentence
 msgid ""
 "The <i>data license</i> you select above only applies to the contents of "
 "any resource files that you add to this dataset. By submitting this form,"
@@ -726,278 +686,200 @@ msgstr ""
 "href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Licence de base de"
 " données ouvertes</a>."
 
+#. nl
+msgid "Edit"
+msgstr ""
+
+#. nl, fr
+msgid "Admin"
+msgstr "Admin"
+
+#. nl, fr
+msgid "View profile"
+msgstr "Voir profil"
+
+#. de
+msgid "Dashboard"
+msgstr ""
+
+msgid "Settings"
+msgstr "Paramètres"
+
+#. de
+msgid "Log out"
+msgstr ""
+
+#. en, fr
+msgid "Organizations"
+msgstr "Les organisations"
+
+#. fr
+msgid "Search"
+msgstr "Recherche"
+
+#. nl, fr, de
+msgid "Search datasets..."
+msgstr "Recherche des ensembles de données..."
+
+#. nl, de
+msgid "Name Ascending"
+msgstr ""
+
+#. nl, de
+msgid "Name Descending"
+msgstr ""
+
+#. nl, fr
+msgid "Order by"
+msgstr "Ordre par"
+
+#. nl, fr, de
+msgid "Activity from items that I'm following"
+msgstr "Activité à partir d'éléments que je suis"
+
+#. nl, fr, de
 msgid "Why Sign Up?"
 msgstr "Pourquoi s'inscrire?"
 
+#. nl, fr, de
 msgid "Register for an Account"
 msgstr "Inscrivez-vous pour un compte"
 
+#. nl, fr, de
 msgid "News feed"
 msgstr "Fil d'actualité"
 
+#. fr, de
 msgid "Go"
 msgstr "Aller"
 
+#. nl, fr, de
 msgid "There are no {facet_type} that match this search"
 msgstr "Aucune {facet_type} ne correspond à cette recherche"
 
+#. nl, fr, de
 msgid "Show Only Popular {facet_type}"
 msgstr "Popular {facet_type}"
 
+#. fr, de
 msgid "Show More {facet_type}"
 msgstr "Voir plus {facet_type}"
 
+#. nl, de
 msgid "Draft"
-msgstr "Brouillon"
+msgstr ""
 
+#. nl, en, fr, de
 #, fuzzy
 msgid "View {organization_name}"
 msgstr "Mes organisations"
 
+#. fr, de
 #, fuzzy
 msgid "0 Datasets"
 msgstr "0 Jeux de données"
 
-msgid "{num} Dataset"
-msgid_plural "{num} Datasets"
-msgstr[0] "{num} Jeu de données"
-msgstr[1] "{num} Jeux de données"
-
+#. de
 msgid "Deleted"
-msgstr "Supprimé"
+msgstr ""
 
+#. fr, de
 msgid "About"
 msgstr "A propos"
 
+#. nl, fr, de
 msgid "E.g. environment"
 msgstr "Par ex. environnement"
 
+#. de
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
+#. de
 msgid "Welcome"
-msgstr "Bienvenue"
+msgstr ""
 
+#. fr, de
 msgid "CKAN API"
 msgstr "CKAN API"
 
+#. nl, en, fr
 msgid "Registration"
 msgstr "Enregistrement"
 
+#. nl, fr
 msgid "Register"
 msgstr "S'enregistrer"
 
+#. nl, fr, de
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié?"
 
+#. nl
 msgid "No problem, use our password recovery form to reset it."
 msgstr ""
 "Aucun problème, utilisez notre formulaire de regénération du mot de passe"
 " pour le réinitialiser."
 
+#. fr
 msgid "Forgotten your password?"
 msgstr "Mot de passe oublié?"
 
-msgid "Create an Account"
-msgstr "Créer un Compte"
-
+#. nl
 msgid "Then sign right up, it only takes a minute."
-msgstr "Alors inscrivez-vous tout de suite, il n'y en a que pour une minute."
+msgstr ""
 
+#. nl, fr
 msgid "Need an Account?"
 msgstr "Vous avez besoin d'un Compte?"
 
+#. en, de
 msgid "My Organizations"
-msgstr "Mes organisations"
+msgstr ""
 
+#. en, de
 msgid "My Datasets"
-msgstr "Mes jeux de données"
+msgstr ""
 
+#. nl, fr
 msgid "Filter Results"
 msgstr "Filtrer les résultats"
 
-msgid "Language"
-msgstr "Langue"
-
+#. fr
 msgid "What's a resource?"
 msgstr "Qu'est-ce qu'une ressource?"
 
-msgid "Filters"
-msgstr "Filtres"
-
+#. de
 msgid "Log in"
-msgstr "Connexion"
+msgstr ""
 
-msgid "Remove"
-msgstr "Supprimer"
-
+#. en
 msgid "UK Open Government Licence (OGL)"
 msgstr ""
 
-msgid "Unauthorized to create a group"
-msgstr ""
-
-msgid "Integrity Error"
-msgstr ""
-
-msgid "Group not found"
-msgstr ""
-
-msgid "Link"
-msgstr ""
-
+#. nl, fr, de
 msgid "Link to a URL on the internet (you can also link to an API)"
 msgstr ""
 "Lien vers une URL sur l'internet (vous pouvez également établir un lien "
 "vers une API)"
 
+#. nl, fr
 msgid "Upload"
 msgstr "Télécharger"
 
-msgid "Image"
-msgstr "Image"
-
+#. nl, de
 msgid "Upload a file on your computer"
-msgstr "Télécharger un fichier sur votre ordinateur"
-
-msgid "URL"
 msgstr ""
 
-msgid "File"
-msgstr "Fichier"
-
-#, python-format
-msgid "Tag \"%s\" length is less than minimum %s"
-msgstr ""
-
-#, python-format
-msgid "Tag \"%s\" length is more than maximum %i"
-msgstr ""
-
-msgid "Datasets"
-msgstr "Jeux de données"
-
-msgid "Members"
-msgstr ""
-
+#. nl
 msgid "Organization"
 msgstr ""
 
-msgid "read more"
-msgstr ""
-
-msgid "There is no description for this organization"
-msgstr ""
-
-msgid "Followers"
-msgstr ""
-
+#. nl, fr
 msgid "Private"
 msgstr "Privé"
 
-msgid "New view"
-msgstr ""
-
-msgid "Unfollow"
-msgstr ""
-
-msgid "Follow"
-msgstr ""
-
-msgid "Format"
-msgstr ""
-
-msgid "Explore"
-msgstr ""
-
-msgid "Preview"
-msgstr ""
-
-msgid "More information"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Go to resource"
-msgstr ""
-
-msgid "Edit resource"
-msgstr ""
-
-msgid "Views"
-msgstr ""
-
-msgid "Clear Upload"
-msgstr ""
-
-msgid "Public"
-msgstr ""
-
-msgid "http://example.com/my-image.jpg"
-msgstr ""
-
-msgid "Image URL"
-msgstr ""
-
-msgid "Additional Information"
-msgstr ""
-
-msgid "Field"
-msgstr ""
-
-msgid "Value"
-msgstr ""
-
-msgid "Last updated"
-msgstr ""
-
-msgid "unknown"
-msgstr ""
-
-msgid "Created"
-msgstr ""
-
-msgid "State"
-msgstr ""
-
+#. nl, fr, de
 msgid "The form contains invalid entries:"
 msgstr "Le formulaire contient des entrées non valides"
-
-msgid "No License Provided"
-msgstr ""
-
-msgid "License"
-msgstr ""
-
-msgid "This dataset satisfies the Open Definition."
-msgstr ""
-
-msgid "You haven't created any datasets."
-msgstr ""
-
-msgid "Create one now?"
-msgstr ""
-
-msgid "Open ID"
-msgstr ""
-
-msgid "Username"
-msgstr ""
-
-msgid "Email"
-msgstr ""
-
-msgid "This means only you can see this"
-msgstr ""
-
-msgid "Member Since"
-msgstr ""
-
-msgid "Visibility"
-msgstr "Visibilité"
-
-msgid "Edit"
-msgstr ""
-
 

--- a/ckanext/benap/i18n/nl/LC_MESSAGES/ckanext-benap.po
+++ b/ckanext/benap/i18n/nl/LC_MESSAGES/ckanext-benap.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-benap 0.0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-21 10:49+0000\n"
+"POT-Creation-Date: 2025-08-22 13:44+0000\n"
 "PO-Revision-Date: 2019-09-20 17:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl\n"
@@ -19,6 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.15.0\n"
 
+#. nl, fr, de
 #: ckanext/benap/assets/js/scheming-doc_upload.js:78
 #: ckanext/benap/assets/js/scheming-logo_upload.js:72
 #: ckanext/benap/assets/js/scheming-proxy_upload.js:72
@@ -498,21 +499,21 @@ msgstr "Bv. autodelen, trein, fietsverhuur, enz."
 msgid "Popular Tags"
 msgstr "Populaire tags"
 
-#: ckanext/benap/templates/home/snippets/search.html:27
+#: ckanext/benap/templates/home/snippets/search.html:31
 msgid "ADD NEW DATA"
 msgstr "Datasets en diensten toevoegen"
 
-#: ckanext/benap/templates/home/snippets/search.html:29
+#: ckanext/benap/templates/home/snippets/search.html:33
 msgid "Data providers can easily add data to the catalogue."
 msgstr ""
 "Gegevensaanbieders kunnen eenvoudig datasets en diensten registreren op "
 "het NAP ITS."
 
-#: ckanext/benap/templates/home/snippets/search.html:31
+#: ckanext/benap/templates/home/snippets/search.html:35
 msgid "Add Data"
 msgstr "Gegevens toevoegen"
 
-#: ckanext/benap/templates/package/search.html:11
+#: ckanext/benap/templates/package/search.html:17
 msgid "close"
 msgstr "Sluit"
 
@@ -547,7 +548,7 @@ msgstr ""
 msgid "Signed"
 msgstr "Ondertekend"
 
-#: ckanext/benap/templates/scheming/package/read.html:14
+#: ckanext/benap/templates/scheming/package/read.html:13
 #: ckanext/benap/templates/scheming/package/snippets/package_form.html:15
 #: ckanext/benap/templates/scheming/package/snippets/resource_form.html:15
 msgid ""
@@ -555,7 +556,7 @@ msgid ""
 "    might not be compatible with ckanext-scheming"
 msgstr ""
 
-#: ckanext/benap/templates/scheming/package/read.html:34
+#: ckanext/benap/templates/scheming/package/read.html:33
 msgid "Transportation modes covered"
 msgstr "Vervoerswijzen gedekt"
 
@@ -573,7 +574,7 @@ msgctxt "Status"
 msgid "State"
 msgstr "Status"
 
-#: ckanext/benap/templates/snippets/facet_list.html:6
+#: ckanext/benap/templates/snippets/facet_list.html:5
 msgid "Transportation modes"
 msgstr "Vervoersmodi"
 
@@ -643,62 +644,21 @@ msgstr ""
 
 #. -------- Translations specific to ckan source --------
 msgid "Sysadmin settings"
-msgstr "Instelligen van systeemadministrator"
+msgstr "Instellingen van systeemadministrator"
 
-msgid "Admin"
-msgstr "Admin"
+#. fr, nl
+msgid "<p class=\"extra\">Please try another search.</p>"
+msgstr "<p class=\"extra\">Gelieve een andere zoekterm te gebruiken.</p>"
 
-msgid "View profile"
-msgstr "Profiel bekijken"
-
-#, python-format
-msgid "Dashboard (%(num)d new item)"
-msgid_plural "Dashboard (%(num)d new items)"
-msgstr[0] "Dashboard (%(num)d nieuw item)"
-msgstr[1] "Dashboard (%(num)d nieuwe items)"
-
-msgid "Dashboard"
-msgstr "Dashboard"
-
-msgid "Settings"
-msgstr "Instellingen"
-
-msgid "Log out"
-msgstr ""
-
-msgid "Organizations"
-msgstr "Organisaties"
-
-msgid "Groups"
-msgstr "Groepen"
-
-msgid "Search"
-msgstr "Zoek"
-
-msgid "Search datasets..."
-msgstr "Zoek datasets..."
-
-msgid "Name Ascending"
-msgstr "Naam Aflopend"
-
-msgid "Name Descending"
-msgstr "Naam Oplopend"
-
-msgid "Order by"
-msgstr "Sorteren op"
-
-#: ckan/templates/snippets/search_form.html:83
-msgid " <p class=\"extra\">Please try another search.</p> "
-msgstr ""
-
+#. fr, nl, de
 msgid ""
-" <p id=\"search-error\"><strong>There was an error while "
-"searching.</strong> Please try again.</p> "
+"<p id=\"search-error\"><strong>There was an error while "
+"searching.</strong> Please try again.</p>"
 msgstr ""
+"<p id=\"search-error\"><strong>Er was een fout tijdens het "
+"zoeken.</strong> Gelieve opnieuw te proberen.</p>"
 
-msgid "Activity from items that I'm following"
-msgstr "Activiteit van items die ik volg"
-
+#. fr, nl, de, en - remove first sentence
 msgid ""
 "The <i>data license</i> you select above only applies to the contents of "
 "any resource files that you add to this dataset. By submitting this form,"
@@ -712,277 +672,200 @@ msgstr ""
 "href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Open Database "
 "License</a>."
 
+#. nl
+msgid "Edit"
+msgstr "Bewerk"
+
+#. nl, fr
+msgid "Admin"
+msgstr "Admin"
+
+#. nl, fr
+msgid "View profile"
+msgstr "Profiel bekijken"
+
+#. de
+msgid "Dashboard"
+msgstr ""
+
+msgid "Settings"
+msgstr "Instellingen"
+
+#. de
+msgid "Log out"
+msgstr ""
+
+#. en, fr
+msgid "Organizations"
+msgstr ""
+
+#. fr
+msgid "Search"
+msgstr ""
+
+#. nl, fr, de
+msgid "Search datasets..."
+msgstr "Zoek datasets..."
+
+#. nl, de
+msgid "Name Ascending"
+msgstr "Naam Aflopend"
+
+#. nl, de
+msgid "Name Descending"
+msgstr "Naam Oplopend"
+
+#. nl, fr
+msgid "Order by"
+msgstr "Sorteren op"
+
+#. nl, fr, de
+msgid "Activity from items that I'm following"
+msgstr "Activiteit van items die ik volg"
+
+#. nl, fr, de
 msgid "Why Sign Up?"
 msgstr "Waarom registreren?"
 
+#. nl, fr, de
 msgid "Register for an Account"
 msgstr "Registreer voor een account"
 
+#. nl, fr, de
 msgid "News feed"
 msgstr "Nieuwsfeed"
 
+#. fr, de
 msgid "Go"
-msgstr "Ga"
+msgstr ""
 
+#. nl, fr, de
 msgid "There are no {facet_type} that match this search"
 msgstr "Er zijn geen {facet_type} dat overeenstemmen met deze zoekactie"
 
+#. nl, fr, de
 msgid "Show Only Popular {facet_type}"
 msgstr "Popular {facet_type}"
 
+#. fr, de
 msgid "Show More {facet_type}"
-msgstr "Toon meer {facet_type}"
+msgstr ""
 
+#. nl, de
 msgid "Draft"
 msgstr "Concept"
 
+#. nl, en, fr, de
 #, fuzzy
 msgid "View {organization_name}"
 msgstr "Organisaties"
 
+#. fr, de
 #, fuzzy
 msgid "0 Datasets"
 msgstr "0 Datasets"
 
-msgid "{num} Dataset"
-msgid_plural "{num} Datasets"
-msgstr[0] "{num} Dataset"
-msgstr[1] "{num} Datasets"
-
+#. de
 msgid "Deleted"
-msgstr "Verwijderd"
+msgstr ""
 
+#. fr, de
 msgid "About"
-msgstr "Over"
+msgstr ""
 
+#. nl, fr, de
 msgid "E.g. environment"
 msgstr "Bv. leefmilieu"
 
+#. de
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
+#. de
 msgid "Welcome"
-msgstr "Welkom"
+msgstr ""
 
+#. fr, de
 msgid "CKAN API"
-msgstr "CKAN API"
+msgstr ""
 
+#. nl, en, fr
 #, fuzzy
 msgid "Registration"
 msgstr "Organisaties"
 
+#. nl, fr
 msgid "Register"
 msgstr "Registreren"
 
+#. nl, fr, de
 msgid "Forgot your password?"
 msgstr "Uw wachtwoord vergeten?"
 
+#. nl
 msgid "No problem, use our password recovery form to reset it."
 msgstr ""
 "Geen probleem, gebruik ons wachtwoord herstelformulier om uw wachtwoord "
 "opnieuw in te stellen."
 
+#. fr
 msgid "Forgotten your password?"
-msgstr "Wachtwoord vergeten?"
+msgstr ""
 
-msgid "Create an Account"
-msgstr "Account aanmaken"
-
+#. nl
 msgid "Then sign right up, it only takes a minute."
 msgstr "Schrijf u nu in, het neemt slechts een minuut."
 
+#. nl, fr
 msgid "Need an Account?"
 msgstr "Heeft uw een Account nodig?"
 
+#. en, de
 #, fuzzy
 msgid "My Organizations"
 msgstr "Mijn organisaties"
 
+#. en, de
 #, fuzzy
 msgid "My Datasets"
 msgstr "Mijn Datasets"
 
+#. nl, fr
 msgid "Filter Results"
 msgstr "Resulaten filteren"
 
-msgid "Language"
-msgstr "Taal"
-
+#. fr
 msgid "What's a resource?"
-msgstr "Wat is een bron?"
+msgstr ""
 
-msgid "Filters"
-msgstr "Filters"
-
+#. de
 msgid "Log in"
-msgstr "Inloggen"
+msgstr ""
 
-msgid "Remove"
-msgstr "Verwijder"
-
+#. en
 msgid "UK Open Government Licence (OGL)"
 msgstr ""
 
-msgid "Unauthorized to create a group"
-msgstr ""
-
-msgid "Integrity Error"
-msgstr ""
-
-msgid "Group not found"
-msgstr ""
-
-msgid "Link"
-msgstr ""
-
+#. nl, fr, de
 msgid "Link to a URL on the internet (you can also link to an API)"
 msgstr "Link naar een URL op het internet (u kunt ook linken naar een API)"
 
+#. nl, fr
 msgid "Upload"
 msgstr "Uploaden"
 
-msgid "Image"
-msgstr "Afbeelding"
-
+#. nl, de
 msgid "Upload a file on your computer"
 msgstr "Upload een bestand vanop uw computer"
 
-msgid "URL"
-msgstr ""
-
-msgid "File"
-msgstr "Bestand"
-
-#, python-format
-msgid "Tag \"%s\" length is less than minimum %s"
-msgstr ""
-
-#, python-format
-msgid "Tag \"%s\" length is more than maximum %i"
-msgstr ""
-
-msgid "Datasets"
-msgstr "Datasets"
-
-msgid "Members"
-msgstr ""
-
+#. nl
 msgid "Organization"
 msgstr "Organisatie"
 
-msgid "read more"
-msgstr ""
-
-msgid "There is no description for this organization"
-msgstr ""
-
-msgid "Followers"
-msgstr ""
-
+#. nl, fr
 msgid "Private"
 msgstr "Privaat"
 
-msgid "New view"
-msgstr ""
-
-msgid "Unfollow"
-msgstr ""
-
-msgid "Follow"
-msgstr ""
-
-msgid "Format"
-msgstr ""
-
-msgid "Explore"
-msgstr ""
-
-msgid "Preview"
-msgstr ""
-
-msgid "More information"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Go to resource"
-msgstr ""
-
-msgid "Edit resource"
-msgstr ""
-
-msgid "Views"
-msgstr ""
-
-msgid "Clear Upload"
-msgstr ""
-
-msgid "Public"
-msgstr ""
-
-msgid "http://example.com/my-image.jpg"
-msgstr ""
-
-msgid "Image URL"
-msgstr ""
-
-msgid "Additional Information"
-msgstr ""
-
-msgid "Field"
-msgstr ""
-
-msgid "Value"
-msgstr ""
-
-msgid "Last updated"
-msgstr ""
-
-msgid "unknown"
-msgstr ""
-
-msgid "Created"
-msgstr ""
-
-msgid "State"
-msgstr ""
-
+#. nl, fr, de
 msgid "The form contains invalid entries:"
 msgstr "Het formulier bevat ongeldige gegevens"
-
-msgid "No License Provided"
-msgstr ""
-
-msgid "License"
-msgstr ""
-
-msgid "This dataset satisfies the Open Definition."
-msgstr ""
-
-msgid "You haven't created any datasets."
-msgstr ""
-
-msgid "Create one now?"
-msgstr ""
-
-msgid "Open ID"
-msgstr ""
-
-msgid "Username"
-msgstr ""
-
-msgid "Email"
-msgstr ""
-
-msgid "This means only you can see this"
-msgstr ""
-
-msgid "Member Since"
-msgstr ""
-
-msgid "Visibility"
-msgstr "Zichtbaarheid"
-
-msgid "Edit"
-msgstr "Bewerk"


### PR DESCRIPTION
further fixes the split between plugin-specific translations and translations to overwrite ckan-core. This removes obsolete translations from ckan-translations-overwrite: translations that had no overwrites defined, or translations that were already the same in ckan-core

This also sets a comment which language is being overwritten, for every line.