### PR TITLE
fix bugs related to lang_text and bad concept uris

### DIFF
--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -170,11 +170,14 @@ def lang_text(translations, language = None, fallback = True):
     If no dict is passed, the function will return the result without any changes.
     This is a useful default for fields that can be both just a string or a dict of translations.
     """
-    translation = translations[language or lang()] or None
-    if not translation and fallback:
-        # TODO: this order could come from ckan.locale_order config key
-        translation = translations['en'] or translations['nl'] or translations['fr'] or translations['de'] or None
-    return translation
+    if translations and hasattr(translations, 'get'):
+        translation = translations.get(language or lang(), None)
+        if not translation and fallback:
+            # TODO: this order could come from ckan.locale_order config key
+            translation = translations.get('en') or translations.get('nl') or translations.get('fr') or translations.get('de') or None
+        return translation
+    else:
+        return translations
 
 # TODO: remove after replacing this with lang_text in fluent fork
 def scheming_language_text_fallback(field_data, language_data):

--- a/ckanext/benap/helpers/concepts.py
+++ b/ckanext/benap/helpers/concepts.py
@@ -20,9 +20,7 @@ def get_concept_label(concept_uri, language = None, collection=CONCEPTS):
             # The same string value for all languages
             return concept
     except KeyError as e:
-        # TODO: some skos concept-scheme (URI!) based forms contain the string "Other" as an option.
-        # This should probably be refactored out.
-        if concept_uri == "Other":
-            return "Other"
+        # TODO: some skos concept-scheme (URI!) based forms contain strings like "Other" or "XML" as an option.
+        # this should probably be refactored out. For now, just return that string value instead.
         log.error(f"No concept known by uri \"{concept_uri}\"")
-        raise e
+        return concept_uri

--- a/ckanext/benap/templates/snippets/package_item.html
+++ b/ckanext/benap/templates/snippets/package_item.html
@@ -20,7 +20,7 @@
     </div>
 {% endblock %}
 
-{% set notes_translated = h.benap_lang_text(package.notes_translated) %}
+{% set notes_translated = h.benap_lang_text(package.get('notes_translated')) %}
 
 {% block notes %}
     {% if notes_translated %}


### PR DESCRIPTION
It was already mentioned in the docs of the function but not yet implemented:
If no dict is passed, just return the object itself.
If certain languages are missing, fallback to others.

The main difference is using .get(), as was originally intended.

If concept_uri is faulty, just return it instead of erroring
This is not a clean solution, but the data sometimes contains non-uri data as concept uris. Erroring will make the app crash. Instead, just return the "uri" as is, so the frontend will at least show something.