### PR TITLE
fix optional fields requiring field to be present

### DIFF
--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -1014,7 +1014,7 @@
       ],
       "error_snippet": "fluent_text.html",
       "output_validators": "fluent_core_translated_output",
-      "validators": "fluent_text",
+      "validators": "default({}) fluent_text",
       "form_snippet": null,
       "display_snippet": "fluent_markdown_fallback.html"
     },
@@ -1094,7 +1094,7 @@
       "display_snippet": "fluent_markdown_fallback.html",
       "error_snippet": "fluent_text.html",
       "output_validators": "fluent_core_translated_output",
-      "validators": "fluent_text benap_is_choice_null benap_license_fields_conditional_validation"
+      "validators": "default({}) fluent_text benap_is_choice_null benap_license_fields_conditional_validation"
     }
   ]
 }

--- a/ckanext/benap/benap_schema.json
+++ b/ckanext/benap/benap_schema.json
@@ -282,7 +282,7 @@
     },
       "form_placeholder": "+32XXXXXXXX",
       "form_snippet": null,
-      "validators": "phone_number_validator benap_contact_point_org_fields_consistency_check"
+      "validators": "default('') phone_number_validator benap_contact_point_org_fields_consistency_check"
     },
     {
       "field_name": "publisher_name",

--- a/ckanext/benap/logic/validators.py
+++ b/ckanext/benap/logic/validators.py
@@ -257,7 +257,7 @@ def benap_tag_string_convert(key, flattened_data, errors, context):
         tagname_match = re.compile('[\w \-.]*$', re.UNICODE)
         if not tagname_match.match(tag):
             raise Invalid(_('Tag "%s" must be alphanumeric '
-                            'characters or symbols: -_.') % (value))
+                            'characters or symbols: -_.') % (tag))
 
 def logo_extensions(value):
     if value and len(value) > 0:

--- a/ckanext/benap/presets.json
+++ b/ckanext/benap/presets.json
@@ -37,6 +37,16 @@
         "display_snippet": null,
         "validators": "scheming_required scheming_choices"
       }
+    },
+    {
+      "preset_name": "fluent_markdown",
+      "values": {
+        "form_snippet": "fluent_markdown.html",
+        "display_snippet": "fluent_markdown.html",
+        "error_snippet": "fluent_text.html",
+        "validators": "default({}) fluent_text",
+        "output_validators": "fluent_text_output"
+      }
     }
   ]
 }


### PR DESCRIPTION
some fields are optional but still expect the field to be present and set "correctly" to an empty value. This changes so those fields can be missing too (useful for api usage).