### PR TITLE
remove convert_validation_list_to_JSON helper

### DIFF
--- a/ckanext/benap/helpers/__init__.py
+++ b/ckanext/benap/helpers/__init__.py
@@ -217,24 +217,6 @@ def organization_by_id(id):
 def organization_name_by_id(id):
     return organization_name(organization_by_id(id))
 
-
-def convert_validation_list_to_JSON(data):
-    """
-    Converts a string containing a JSON-like structure into a proper JSON list format.
-
-    If the input string contains curly braces ('{', '}'), it is assumed to be a
-    JSON-like structure and is converted by replacing the curly braces with square
-    brackets ('[', ']'). If not, the string is wrapped in a JSON array format.
-
-    This function is particularly useful for handling cases where a validation
-    process converts a JSON string into a list format unexpectedly.
-    """
-    if '{' in data:
-        data_string = data.replace('{', '[').replace('}', ']')
-    else:
-        data_string = '["{}"]'.format(data)
-    return data_string
-
 def benap_get_organization_field_by_id(org_id, field_name):
     """
     Retrieve the specified field value from an organization's data based on the organization id.

--- a/ckanext/benap/plugin.py
+++ b/ckanext/benap/plugin.py
@@ -11,7 +11,7 @@ from flask import Blueprint
 from ckanext.benap.helpers import ontology_helper, organization_name, organisation_names_for_autocomplete, \
     get_translated_tags, scheming_language_text, format_datetime, ckan_tag_to_transport_mode_concept_label,\
     parse_embedded_links, organization_name_by_id, lang_text, \
-    convert_validation_list_to_JSON, benap_get_organization_field_by_id,\
+    benap_get_organization_field_by_id,\
     benap_get_organization_field_by_specified_field, benap_retrieve_dict_items_or_keys_or_values, get_translated_category_and_sub_category, \
     benap_retrieve_org_title_tel_email, benap_retrieve_raw_choices_list, benap_tag_update_helper, _c, is_member_of_org, get_facet_label_function, get_facet_name_label_function
 
@@ -70,7 +70,6 @@ class BenapPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultTr
             'format_datetime': format_datetime,
             'benap_organization_name': organization_name,
             'benap_organization_name_by_id': organization_name_by_id,
-            'benap_convert_validation_list_to_JSON': convert_validation_list_to_JSON,
             'benap_get_organization_field_by_id': benap_get_organization_field_by_id,
             'benap_get_organization_field_by_specified_field': benap_get_organization_field_by_specified_field,
             'benap_retrieve_dict_items_or_keys_or_values': benap_retrieve_dict_items_or_keys_or_values,

--- a/ckanext/benap/templates/scheming/display_snippets/multiple_choice.html
+++ b/ckanext/benap/templates/scheming/display_snippets/multiple_choice.html
@@ -1,7 +1,4 @@
 {%- set values = data[field.field_name] -%}
-{%- if '{' in values|string -%}
-    {%- set values = h.benap_convert_validation_list_to_JSON(values) -%}
-{%- endif -%}
 {%- set labels = [] -%}
 
 {%- for choice in h.scheming_field_choices(field) -%}

--- a/ckanext/benap/templates/scheming/form_snippets/multiple_checkbox.html
+++ b/ckanext/benap/templates/scheming/form_snippets/multiple_checkbox.html
@@ -21,8 +21,7 @@
                     name="{{ field.field_name }}"
                     value="{{ val }}"
                     {%- set field_value = data[field.field_name] -%}
-                    {%- set converted_value = h.benap_convert_validation_list_to_JSON(field_value) -%}
-                    {{ "checked " if val in field_value or val in converted_value }} />
+                    {{ "checked " if val in field_value }} />
                 {{ label }}
             </label>
         {%- endfor -%}

--- a/ckanext/benap/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/benap/templates/scheming/form_snippets/multiple_select.html
@@ -30,7 +30,7 @@
     {%- for val, label in choices -%}
       <option id="field-{{ field.field_name }}-{{ val }}"
           value="{{ val }}"
-          {{"selected " if val in h.benap_convert_validation_list_to_JSON(data[field.field_name]) }} />
+          {{"selected " if val in data[field.field_name] }} />
         {{ label }}
       </option>
     {%- endfor -%}


### PR DESCRIPTION
The history of this helper is dubious. There is invalid data in the database, that this helper helps to view. However, that data should have just been converted before persisting instead. This is a hacky patchjob.

Remove this helper and instead migrate the data in the database. This means converting text to form ["...","..."]

Faulty instances are limited, so this is done by hand.