### PR TITLE
Notify admins when a new document of compliance is uploaded.

### DIFF
--- a/ckanext/benap/constants/__init__.py
+++ b/ckanext/benap/constants/__init__.py
@@ -1,0 +1,5 @@
+DOC_FIELDS = {
+     'rtti_upload_doc': 'RTTI',
+     'srti_upload_doc': 'SRTI',
+     'sstp_upload_doc': 'SSTP',
+}

--- a/ckanext/benap/logic/action.py
+++ b/ckanext/benap/logic/action.py
@@ -4,6 +4,7 @@ from ckan.lib.helpers import url_for_static
 from ckan import model
 import sqlalchemy
 from ckanext.benap.constants import DOC_FIELDS
+import logging
 
 # Copied from https://github.com/belgium-its-steering-committee/ckanext-scheming/blob/MobilityDCAT/root/ckanext/scheming/logic.py#L85
 @tk.side_effect_free
@@ -110,37 +111,49 @@ def organization_patch(original_action, context, data_dict):
     return _organization_change(original_action, context, data_dict)
 
 def _organization_change(original_action, context, data_dict):
+    logger = logging.getLogger('ckanext-benap')
     organization = original_action(context, data_dict)
 
     files = [data_dict[doc] for doc in DOC_FIELDS.keys() if data_dict[doc]]
     if files:
-        # TODO: move this to a background job
-        sysadmins = \
-            model.Session.query(model.User) \
-            .filter(model.User.sysadmin) \
-            .all()
+        logger.info("Mailing sysadmins...")
 
-        for sysadmin in sysadmins:
-            if not sysadmin.email:
-                continue
-            for file in files:
-                compliance_type = DOC_FIELDS[file.name]
-                render_vars = {
-                    'user_name': sysadmin.display_name or sysadmin.name,
-                    'organization_title': data_dict['title'],
-                    'organization_url': tk.url_for('organization.about', _external=True, id=data_dict['id']),
-                    'compliance_type': compliance_type
-                }
-                # TODO: i18n (for the sysadmin, not for the uploader)
-                subject = tk.render('emails/doc_notify_subject.txt', render_vars)
-                body = tk.render('emails/doc_notify.txt', render_vars)
-                body_html = tk.render('emails/doc_notify.html', render_vars)
+        try:
+            sysadmins = \
+                model.Session.query(model.User) \
+                .filter(model.User.sysadmin) \
+                .all()
+            logger.debug(f"Found {len(sysadmins)} sysadmins.")
 
-                tk.mail_user(
-                    recipient=sysadmin,
-                    subject=subject,
-                    body=body,
-                    body_html=body_html
-                )
+            for sysadmin in sysadmins:
+                if not sysadmin.email:
+                    continue
+                try:
+                    for file in files:
+                        compliance_type = DOC_FIELDS[file.name]
+                        render_vars = {
+                            'user_name': sysadmin.display_name or sysadmin.name,
+                            'organization_title': data_dict['title'],
+                            'organization_url': tk.url_for('organization.about', _external=True, id=data_dict['id']),
+                            'compliance_type': compliance_type
+                        }
+                        # TODO: i18n (for the sysadmin, not for the uploader)
+                        subject = tk.render('emails/doc_notify_subject.txt', render_vars)
+                        body = tk.render('emails/doc_notify.txt', render_vars)
+                        body_html = tk.render('emails/doc_notify.html', render_vars)
+
+                        tk.mail_user(
+                            recipient=sysadmin,
+                            subject=subject,
+                            body=body,
+                            body_html=body_html
+                        )
+                except Exception as e:
+                    logger.error(f"Failed to notify admin <{sysadmin.email}>", exc_info=e)
+
+        except Exception as e:
+            logger.error("Failed to notify admins", exc_info=e)
 
     return organization
+
+

--- a/ckanext/benap/templates/emails/doc_notify.html
+++ b/ckanext/benap/templates/emails/doc_notify.html
@@ -1,0 +1,22 @@
+{% trans %}
+
+<p>
+  Dear {{ user_name }},
+</p>
+
+<p>
+  Organization {{ organization_title }} uploaded a document of {{ compliance_type }} compliance.
+</p>
+
+<p>
+  You can find the document
+  <a href="{{ organization_url }}">
+    on the organization page.
+  </a>
+</p>
+
+<p>
+  Have a nice day.
+</p>
+
+{% endtrans %}

--- a/ckanext/benap/templates/emails/doc_notify.txt
+++ b/ckanext/benap/templates/emails/doc_notify.txt
@@ -1,0 +1,13 @@
+{% trans %}
+
+Dear {{ user_name }},
+
+Organization {{ organization_title }} uploaded a document of {{ compliance_type }} compliance.
+
+You can find the document here:
+
+{{ organization_url }}
+
+Have a nice day.
+
+{% endtrans %}

--- a/ckanext/benap/templates/emails/doc_notify_subject.txt
+++ b/ckanext/benap/templates/emails/doc_notify_subject.txt
@@ -1,0 +1,3 @@
+{% trans %}
+  Document of Compliance uploaded for {{ organization_title }}
+{% endtrans %}


### PR DESCRIPTION
This is an initial (but functional) implementation.

There are still 2 TODOs:

- [ ]  Move this to a background job if necessary (sending mails could take some time)
- [ ] Send the emails in the sysadmins language
  - How do we determine that language? AFAIK there is no preferred locale field on user objects
  - Alternatively stick to english or send multilingual emails

Maybe the emails could also contain more information, but I'm not sure what.

<details><summary>Temporary mail SMTP setup instructions</summary>

To test email reception, I would recommend the following settings:

In a `docker-compose.*.yml`:
```yml
services:
  mailpit:
    image: axllent/mailpit:latest
    restart: unless-stopped
    ports:
      - "0.0.0.0:8025:8025"
    environment:
      MP_MAX_MESSAGES: 5000
      # MP_DATABASE: /data/mailpit.db
      MP_SMTP_AUTH_ACCEPT_ANY: 1
      MP_SMTP_AUTH_ALLOW_INSECURE: 1
```
And in your `.env`:
```diff
--- a/.env
+++ b/.env
@@ -35,7 +35,7 @@ CKAN_VERSION=2.11
 CKAN_STORAGE_PATH=/var/lib/ckan
 
 # SMTP settings
-CKAN_SMTP_STARTTLS=True
+# CKAN_SMTP_STARTTLS=True
 CKAN_MAX_UPLOAD_SIZE_MB=100
 TZ=UTC
```
Then configure CKAN to use `mailpit:1025` as SMTP server:
```env
CKAN_SMTP_SERVER=mailpit:1025
```
(Re)start docker compose and navigate to http://localhost:8025/ in your browser and you should see a mail inbox ui.
</details> 